### PR TITLE
Migrate from unittest to pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest configuration and shared fixtures."""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def data_path():
+    """Return the path to the test data directory."""
+    return Path(__file__).parent / "data"
+
+
+@pytest.fixture
+def get_data_file(data_path):
+    """Return a function to get full path to a data file."""
+
+    def _get_data_file(filename):
+        return str(data_path / filename)
+
+    return _get_data_file

--- a/tests/neutronbraggedge/braggedge_handler/braggedge_calculator_test.py
+++ b/tests/neutronbraggedge/braggedge_handler/braggedge_calculator_test.py
@@ -1,136 +1,106 @@
-import unittest
+"""Tests for BraggEdgeCalculator class."""
+
+import pytest
 
 from neutronbraggedge.braggedges_handler.braggedge_calculator import BraggEdgeCalculator
 
 
-class TestBraggEdgesHandler(unittest.TestCase):
-    def setUp(self):
-        pass
+class TestBraggEdgeCalculator:
+    """Tests for Bragg Edge calculator functionality."""
 
     def test_calling_without_arguments(self):
-        """Testing that class can be called with default arguments from python2 and 3"""
-        _handler = BraggEdgeCalculator()
-        self.assertEqual("FCC", _handler.structure)
+        """Class can be called with default arguments."""
+        handler = BraggEdgeCalculator()
+        assert handler.structure == "FCC"
 
-    def test_braggedge_calculator_eror_when_bad_structure_given(self):
-        """Assert in braggedge calculator - error is raised when bad structure given"""
-        _structure_name = "FakeStructure"
-        self.assertRaises(ValueError, BraggEdgeCalculator, _structure_name)
+    def test_braggedge_calculator_error_when_bad_structure_given(self):
+        """Error is raised when bad structure given."""
+        structure_name = "FakeStructure"
+        with pytest.raises(ValueError):
+            BraggEdgeCalculator(structure_name)
 
     def test_right_structure_name_is_passed_in_constructor(self):
-        """Assert that structure name passed in constructor is correctly used"""
-        _structure_name = "BCC"
-        _handler = BraggEdgeCalculator(structure_name=_structure_name)
-        self.assertEqual("BCC", _handler.structure)
+        """Structure name passed in constructor is correctly used."""
+        structure_name = "BCC"
+        handler = BraggEdgeCalculator(structure_name=structure_name)
+        assert handler.structure == "BCC"
 
     def test_right_structure_name_is_passed_in_assigned(self):
-        """Assert that structure name assigned is correctly saved"""
-        _structure_name = "BCC"
-        _handler = BraggEdgeCalculator()
-        _handler.structure = _structure_name
-        self.assertEqual("BCC", _handler.structure)
+        """Structure name assigned is correctly saved."""
+        structure_name = "BCC"
+        handler = BraggEdgeCalculator()
+        handler.structure = structure_name
+        assert handler.structure == "BCC"
 
     def test_right_hkl_number_calculated_for_BCC(self):
-        """Assert that the right number of hkl sets is returned for BCC"""
-        _structure_name = "BCC"
-        _handler = BraggEdgeCalculator(structure_name=_structure_name, number_of_set=5)
-        _handler.calculate_hkl()
-        _hkl = _handler.hkl
-        self.assertEqual(5, len(_hkl))
+        """Right number of hkl sets is returned for BCC."""
+        structure_name = "BCC"
+        handler = BraggEdgeCalculator(structure_name=structure_name, number_of_set=5)
+        handler.calculate_hkl()
+        hkl = handler.hkl
+        assert len(hkl) == 5
 
     def test_right_hkl_number_calculated_for_FCC(self):
-        """Assert that the right number of hkl sets is returned for FCC"""
-        _structure_name = "FCC"
-        _handler = BraggEdgeCalculator(structure_name=_structure_name, number_of_set=5)
-        _handler.calculate_hkl()
-        _hkl = _handler.hkl
-        self.assertEqual(5, len(_hkl))
+        """Right number of hkl sets is returned for FCC."""
+        structure_name = "FCC"
+        handler = BraggEdgeCalculator(structure_name=structure_name, number_of_set=5)
+        handler.calculate_hkl()
+        hkl = handler.hkl
+        assert len(hkl) == 5
 
     def test_right_hkl_set_is_calculated_for_FCC(self):
-        """Assert that the right set of hkl sets is returned for FCC"""
-        _structure_name = "FCC"
-        _handler = BraggEdgeCalculator(structure_name=_structure_name, number_of_set=5)
-        _handler.calculate_hkl()
-        _hkl = _handler.hkl
-        self.assertEqual([1, 1, 1], _hkl[0])
-        self.assertEqual([2, 0, 0], _hkl[1])
-        self.assertEqual([2, 2, 0], _hkl[2])
-        self.assertEqual([2, 2, 2], _hkl[3])
-        self.assertEqual([3, 1, 1], _hkl[4])
+        """Right set of hkl sets is returned for FCC."""
+        structure_name = "FCC"
+        handler = BraggEdgeCalculator(structure_name=structure_name, number_of_set=5)
+        handler.calculate_hkl()
+        hkl = handler.hkl
+        assert hkl[0] == [1, 1, 1]
+        assert hkl[1] == [2, 0, 0]
+        assert hkl[2] == [2, 2, 0]
+        assert hkl[3] == [2, 2, 2]
+        assert hkl[4] == [3, 1, 1]
 
     def test_right_hkl_set_is_calculated_for_BCC(self):
-        """Assert that the right set of hkl sets is returned for BCC"""
-        _structure_name = "BCC"
-        _handler = BraggEdgeCalculator(structure_name=_structure_name, number_of_set=5)
-        _handler.calculate_hkl()
-        _hkl = _handler.hkl
-        self.assertEqual([1, 1, 0], _hkl[0])
-        self.assertEqual([2, 0, 0], _hkl[1])
-        self.assertEqual([2, 1, 1], _hkl[2])
-        self.assertEqual([2, 2, 0], _hkl[3])
-        self.assertEqual([2, 2, 2], _hkl[4])
+        """Right set of hkl sets is returned for BCC."""
+        structure_name = "BCC"
+        handler = BraggEdgeCalculator(structure_name=structure_name, number_of_set=5)
+        handler.calculate_hkl()
+        hkl = handler.hkl
+        assert hkl[0] == [1, 1, 0]
+        assert hkl[1] == [2, 0, 0]
+        assert hkl[2] == [2, 1, 1]
+        assert hkl[3] == [2, 2, 0]
+        assert hkl[4] == [2, 2, 2]
 
     def test_calculate_bragg_edges_algorithm_fail_when_no_lattice_given(self):
-        """Assert that ValueError is correctly raised when no lattice is provided"""
-        _handler = BraggEdgeCalculator(structure_name="BCC")
-        self.assertRaises(ValueError, _handler.calculate_bragg_edges)
+        """ValueError is correctly raised when no lattice is provided."""
+        handler = BraggEdgeCalculator(structure_name="BCC")
+        with pytest.raises(ValueError):
+            handler.calculate_bragg_edges()
 
     def test_d_spacing_for_first_hkl_of_bcc(self):
-        """Assert the d_spacing values for the first BCC structure are correct"""
-        _handler = BraggEdgeCalculator(structure_name="BCC", lattice=1.0)
-        _handler.calculate_hkl()
-        _handler.calculate_bragg_edges()
-        self.assertAlmostEqual(0.7071, _handler.d_spacing[0], delta=0.0001)
-        self.assertAlmostEqual(0.5, _handler.d_spacing[1], delta=0.0001)
-        self.assertAlmostEqual(0.4083, _handler.d_spacing[2], delta=0.0001)
+        """d_spacing values for the first BCC structure are correct."""
+        handler = BraggEdgeCalculator(structure_name="BCC", lattice=1.0)
+        handler.calculate_hkl()
+        handler.calculate_bragg_edges()
+        assert handler.d_spacing[0] == pytest.approx(0.7071, abs=0.0001)
+        assert handler.d_spacing[1] == pytest.approx(0.5, abs=0.0001)
+        assert handler.d_spacing[2] == pytest.approx(0.4083, abs=0.0001)
 
     def test_bragg_edge_for_first_hkl_of_bcc(self):
-        """Assert the bragg edge values for the first BCC structure are correct"""
-        _handler = BraggEdgeCalculator(structure_name="BCC", lattice=1.0)
-        _handler.calculate_hkl()
-        _handler.calculate_bragg_edges()
-        self.assertAlmostEqual(1.4142, _handler.bragg_edges[0], delta=0.0001)
-        self.assertAlmostEqual(1.0, _handler.bragg_edges[1], delta=0.0001)
-        self.assertAlmostEqual(0.8165, _handler.bragg_edges[2], delta=0.0001)
+        """Bragg edge values for the first BCC structure are correct."""
+        handler = BraggEdgeCalculator(structure_name="BCC", lattice=1.0)
+        handler.calculate_hkl()
+        handler.calculate_bragg_edges()
+        assert handler.bragg_edges[0] == pytest.approx(1.4142, abs=0.0001)
+        assert handler.bragg_edges[1] == pytest.approx(1.0, abs=0.0001)
+        assert handler.bragg_edges[2] == pytest.approx(0.8165, abs=0.0001)
 
     def test_d_spacing_for_first_hkl_of_fcc(self):
-        """Assert the d_spacing values for the first FCC structure are correct"""
-        _handler = BraggEdgeCalculator(structure_name="FCC", lattice=1.0)
-        _handler.calculate_hkl()
-        _handler.calculate_bragg_edges()
-        self.assertAlmostEqual(1.1547 / 2.0, _handler.d_spacing[0], delta=0.0001)
-        self.assertAlmostEqual(1.0 / 2.0, _handler.d_spacing[1], delta=0.0001)
-        self.assertAlmostEqual(0.7071 / 2.0, _handler.d_spacing[2], delta=0.0001)
-
-    # def test_bragg_edge_for_first_hkl_of_fcc(self):
-    # """Assert the bragg edge values for the first FCC structure are correct"""
-    # _handler = BraggEdgeCalculator(structure_name = "FCC", lattice=1.)
-    # _handler.calculate_hkl()
-    # _handler.calculate_bragg_edges()
-    # self.assertAlmostEqual(1.1547, _handler.bragg_edges[0], delta=0.0001)
-    # self.assertAlmostEqual(1.0, _handler.bragg_edges[1], delta=0.0001)
-    # self.assertAlmostEqual(0.7071, _handler.bragg_edges[2], delta=0.0001)
-
-    # def test_bragg_edge_calculate_exp_lattice(self):
-    # """Assert braggedge_calculator - experimental lattice correctly calculated"""
-    # _handler = BraggEdgeCalculator(structure_name = "FCC", lattice=1.)
-    # _handler.calculate_hkl()
-    # _bragg_edge_exp_value = np.array([4.15297, 3.59671, 2.54284, 2.16852])
-    # _bragg_edge_exp_error = np.array([0.00017, 0.00010, 0.00008, 0.00007])
-    # _handler.calculate_lattice_array(_bragg_edge_exp_value, _bragg_edge_exp_error)
-    # _lattice_exp = _handler.lattice_experimental
-    # _expected_value = np.array([3.59658, 3.59671, 3.59612, 3.755987])
-    # self.assertAlmostEqual(_expected_value[0], _lattice_exp[0], delta=0.00001)
-    # self.assertAlmostEqual(_expected_value[1], _lattice_exp[1], delta=0.00001)
-    # self.assertAlmostEqual(_expected_value[2], _lattice_exp[2], delta=0.00001)
-    # self.assertAlmostEqual(_expected_value[3], _lattice_exp[3], delta=0.00001)
-    # _expected_error = np.array([0.00015, 0.0001, 0.000113, 0.00012])
-    # _lattice_error = _handler.lattice_error_experimental
-    # self.assertAlmostEqual(_expected_error[0], _lattice_error[0], delta=0.00001)
-    # self.assertAlmostEqual(_expected_error[1], _lattice_error[1], delta=0.00001)
-    # self.assertAlmostEqual(_expected_error[2], _lattice_error[2], delta=0.00001)
-    # self.assertAlmostEqual(_expected_error[3], _lattice_error[3], delta=0.00001)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        """d_spacing values for the first FCC structure are correct."""
+        handler = BraggEdgeCalculator(structure_name="FCC", lattice=1.0)
+        handler.calculate_hkl()
+        handler.calculate_bragg_edges()
+        assert handler.d_spacing[0] == pytest.approx(1.1547 / 2.0, abs=0.0001)
+        assert handler.d_spacing[1] == pytest.approx(1.0 / 2.0, abs=0.0001)
+        assert handler.d_spacing[2] == pytest.approx(0.7071 / 2.0, abs=0.0001)

--- a/tests/neutronbraggedge/braggedge_handler/structure_handler_test.py
+++ b/tests/neutronbraggedge/braggedge_handler/structure_handler_test.py
@@ -1,73 +1,65 @@
-import unittest
+"""Tests for StructureHandler classes."""
+
+import pytest
 
 from neutronbraggedge.braggedges_handler.structure_handler import FCCHandler, StructureHandler
 
 
-class TestBraggEdgesHandler(unittest.TestCase):
-    def setUp(self):
-        pass
+class TestStructureHandler:
+    """Tests for structure handler functionality."""
 
     def test_calling_with_wrong_structure(self):
-        """checking that calling an unknown structure raises an error"""
-        self.assertRaises(ValueError, StructureHandler, "HCC")
+        """Calling an unknown structure raises an error."""
+        with pytest.raises(ValueError):
+            StructureHandler("HCC")
 
     def test_getting_the_right_first_hkl_for_BCC(self):
-        """assert that the first h,k,l values are correct"""
-        _handler = StructureHandler("BCC", 1)
-        _list_hkl = _handler.hkl
-        self.assertEqual([1, 1, 0], _list_hkl[0])
+        """First h,k,l values are correct for BCC."""
+        handler = StructureHandler("BCC", 1)
+        list_hkl = handler.hkl
+        assert list_hkl[0] == [1, 1, 0]
 
     def test_getting_the_right_amount_of_hkl_for_BCC(self):
-        """assert that the right number of hkl set is returned for BCC"""
-        _handler = StructureHandler("BCC", 10)
-        _list_hkl = _handler.hkl
-        _nbr_hkl = len(_list_hkl)
-        self.assertEqual(10, _nbr_hkl)
+        """Right number of hkl set is returned for BCC."""
+        handler = StructureHandler("BCC", 10)
+        list_hkl = handler.hkl
+        nbr_hkl = len(list_hkl)
+        assert nbr_hkl == 10
 
     def test_getting_the_right_first_hkl_value_for_BCC(self):
-        """assert that the first few hkl set calculated are correct for BCC"""
-        _handler = StructureHandler("BCC", 10)
-        _list_hkl = _handler.hkl
-        _nbr_hkl = len(_list_hkl)
-        self.assertEqual([2, 0, 0], _list_hkl[1])
-        self.assertEqual([2, 1, 1], _list_hkl[2])
-        self.assertEqual([2, 2, 0], _list_hkl[3])
-        self.assertEqual([2, 2, 2], _list_hkl[4])
+        """First few hkl set calculated are correct for BCC."""
+        handler = StructureHandler("BCC", 10)
+        list_hkl = handler.hkl
+        assert list_hkl[1] == [2, 0, 0]
+        assert list_hkl[2] == [2, 1, 1]
+        assert list_hkl[3] == [2, 2, 0]
+        assert list_hkl[4] == [2, 2, 2]
 
     def test_getting_the_right_amount_of_hkl_for_FCC(self):
-        """assert that the right number of hkl set is returned for FCC"""
-        _handler = StructureHandler("FCC", 10)
-        _list_hkl = _handler.hkl
-        _nbr_hkl = len(_list_hkl)
-        self.assertEqual(10, _nbr_hkl)
+        """Right number of hkl set is returned for FCC."""
+        handler = StructureHandler("FCC", 10)
+        list_hkl = handler.hkl
+        nbr_hkl = len(list_hkl)
+        assert nbr_hkl == 10
 
     def test_getting_the_right_first_hkl_value_for_FCC(self):
-        """assert that the first few hkl set calculated are correct for FCC"""
-        _handler = StructureHandler("FCC", 10)
-        _list_hkl = _handler.hkl
-        _nbr_hkl = len(_list_hkl)
-        self.assertEqual([1, 1, 1], _list_hkl[0])
-        self.assertEqual([2, 0, 0], _list_hkl[1])
-        self.assertEqual([2, 2, 0], _list_hkl[2])
-        self.assertEqual([2, 2, 2], _list_hkl[3])
-        self.assertEqual([3, 1, 1], _list_hkl[4])
+        """First few hkl set calculated are correct for FCC."""
+        handler = StructureHandler("FCC", 10)
+        list_hkl = handler.hkl
+        assert list_hkl[0] == [1, 1, 1]
+        assert list_hkl[1] == [2, 0, 0]
+        assert list_hkl[2] == [2, 2, 0]
+        assert list_hkl[3] == [2, 2, 2]
+        assert list_hkl[4] == [3, 1, 1]
 
-    def test_is_even_algorith(self):
-        """assert that is_even algorithm is correct"""
-        _fcc = FCCHandler(10)
-        _is_even = _fcc._is_even(0)
-        self.assertTrue(_is_even)
-        _is_even = _fcc._is_even(1)
-        self.assertFalse(_is_even)
+    def test_is_even_algorithm(self):
+        """is_even algorithm is correct."""
+        fcc = FCCHandler(10)
+        assert fcc._is_even(0) is True
+        assert fcc._is_even(1) is False
 
     def test_same_parity_algorithm(self):
-        """assert that same_parity algorithm is correct"""
-        _fcc = FCCHandler(10)
-        _same_parity = _fcc._same_parity(1, 1, 1)
-        self.assertTrue(_same_parity)
-        _same_parity = _fcc._same_parity(1, 1, 2)
-        self.assertFalse(_same_parity)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        """same_parity algorithm is correct."""
+        fcc = FCCHandler(10)
+        assert fcc._same_parity(1, 1, 1) is True
+        assert fcc._same_parity(1, 1, 2) is False

--- a/tests/neutronbraggedge/braggedge_test.py
+++ b/tests/neutronbraggedge/braggedge_test.py
@@ -1,158 +1,161 @@
-import os
-import unittest
+"""Tests for BraggEdge class."""
 
 import numpy as np
+import pytest
 
 from neutronbraggedge.braggedge import BraggEdge
 
 
-class TestBraggEdge(unittest.TestCase):
-    def setUp(self):
-        pass
+class TestBraggEdge:
+    """Tests for main BraggEdge functionality."""
 
     def test_raise_error_when_nothing_passed_in(self):
-        """Assert an error is raised when no material are passed in"""
-        self.assertRaises(ValueError, BraggEdge)
+        """Error is raised when no material are passed in."""
+        with pytest.raises(ValueError):
+            BraggEdge()
 
     def test_raise_error_when_bad_new_material_input_format(self):
-        """Assert an error is raised when the new_material array format is wrong"""
+        """Error is raised when the new_material array format is wrong."""
         new_material = [{"wrong_name": "Ta", "wrong_lattice_constant": 34545}]
-        self.assertRaises(ValueError, BraggEdge, None, new_material)
+        with pytest.raises(ValueError):
+            BraggEdge(None, new_material)
 
     def test_retrieve_correct_metadata_for_single_local_material(self):
-        """Assert the correct metadata are retrieved for a single local material"""
+        """Correct metadata are retrieved for a single local material."""
         new_material = [{"name": "Ta", "lattice": 0.5, "crystal_structure": "BCC"}]
-        _handler = BraggEdge(new_material=new_material)
-        _metadata = _handler.metadata
-        self.assertEqual(0.5, _metadata["lattice"]["Ta"])
-        self.assertEqual("BCC", _metadata["crystal_structure"]["Ta"])
+        handler = BraggEdge(new_material=new_material)
+        metadata = handler.metadata
+        assert metadata["lattice"]["Ta"] == 0.5
+        assert metadata["crystal_structure"]["Ta"] == "BCC"
 
     def test_retrieve_correct_metadata_for_multi_local_material(self):
-        """Assert the correct metadata are retrieved for a couple of local material"""
+        """Correct metadata are retrieved for a couple of local material."""
         new_material = [
             {"name": "Ta", "lattice": 0.5, "crystal_structure": "BCC"},
             {"name": "Ni", "lattice": 1.5, "crystal_structure": "FCC"},
         ]
-        _handler = BraggEdge(new_material=new_material)
-        _metadata = _handler.metadata
-        self.assertEqual(0.5, _metadata["lattice"]["Ta"])
-        self.assertEqual(1.5, _metadata["lattice"]["Ni"])
-        self.assertEqual("BCC", _metadata["crystal_structure"]["Ta"])
-        self.assertEqual("FCC", _metadata["crystal_structure"]["Ni"])
+        handler = BraggEdge(new_material=new_material)
+        metadata = handler.metadata
+        assert metadata["lattice"]["Ta"] == 0.5
+        assert metadata["lattice"]["Ni"] == 1.5
+        assert metadata["crystal_structure"]["Ta"] == "BCC"
+        assert metadata["crystal_structure"]["Ni"] == "FCC"
 
     def test_calculate_d_spacing_for_single_local_material(self):
-        """Assert the d_spacing calculation is correct for a single local material"""
+        """d_spacing calculation is correct for a single local material."""
         new_material = [{"name": "Ta", "lattice": 5.0, "crystal_structure": "BCC"}]
-        _handler = BraggEdge(new_material=new_material)
-        _d_spacing = _handler.d_spacing
-        self.assertAlmostEqual(_d_spacing["Ta"][0], 3.5355, delta=0.0001)
+        handler = BraggEdge(new_material=new_material)
+        d_spacing = handler.d_spacing
+        assert d_spacing["Ta"][0] == pytest.approx(3.5355, abs=0.0001)
 
     def test_calculate_hkl_for_single_local_material(self):
-        """Assert the hkl calculation is correct for a single local material"""
+        """hkl calculation is correct for a single local material."""
         new_material = [{"name": "Ta", "lattice": 5.0, "crystal_structure": "BCC"}]
-        _handler = BraggEdge(new_material=new_material)
-        _hkl = _handler.hkl
-        self.assertEqual(_hkl["Ta"][0], [1, 1, 0])
-        self.assertEqual(_hkl["Ta"][1], [2, 0, 0])
+        handler = BraggEdge(new_material=new_material)
+        hkl = handler.hkl
+        assert hkl["Ta"][0] == [1, 1, 0]
+        assert hkl["Ta"][1] == [2, 0, 0]
 
     def test_retrieving_correct_metadata_for_Ni(self):
-        """Assert the correct metadata are returned for Ni"""
-        _handler = BraggEdge(material="Ni")
-        _metadata = _handler.metadata
-        self.assertAlmostEqual(3.5238, _metadata["lattice"]["Ni"], delta=0.01)
-        self.assertEqual("FCC", _metadata["crystal_structure"]["Ni"])
+        """Correct metadata are returned for Ni."""
+        handler = BraggEdge(material="Ni")
+        metadata = handler.metadata
+        assert metadata["lattice"]["Ni"] == pytest.approx(3.5238, abs=0.01)
+        assert metadata["crystal_structure"]["Ni"] == "FCC"
 
     def test_retrieving_correct_number_and_first_2_values_hkl_for_Si(self):
-        """Assert the correct hkl first 2values are returned for Si, and the correct number"""
-        _handler = BraggEdge(material="Si", number_of_bragg_edges=4)
-        _hkl = _handler.hkl["Si"]
-        self.assertEqual([1, 1, 1], _hkl[0])
-        self.assertEqual([2, 0, 0], _hkl[1])
-        self.assertEqual(4, len(_hkl))
+        """Correct hkl first 2 values are returned for Si, and the correct number."""
+        handler = BraggEdge(material="Si", number_of_bragg_edges=4)
+        hkl = handler.hkl["Si"]
+        assert hkl[0] == [1, 1, 1]
+        assert hkl[1] == [2, 0, 0]
+        assert len(hkl) == 4
 
     def test_calculating_d_spacing_values_for_Ni(self):
-        """Assert the first 3 d_spacing are correct for Ni"""
-        _handler = BraggEdge(material="Ni", number_of_bragg_edges=4)
-        _d_spacing = _handler.d_spacing["Ni"]
-        self.assertAlmostEqual(2.0345, _d_spacing[0], delta=0.001)
-        self.assertAlmostEqual(1.7619, _d_spacing[1], delta=0.001)
-        self.assertAlmostEqual(1.2459, _d_spacing[2], delta=0.001)
+        """First 3 d_spacing are correct for Ni."""
+        handler = BraggEdge(material="Ni", number_of_bragg_edges=4)
+        d_spacing = handler.d_spacing["Ni"]
+        assert d_spacing[0] == pytest.approx(2.0345, abs=0.001)
+        assert d_spacing[1] == pytest.approx(1.7619, abs=0.001)
+        assert d_spacing[2] == pytest.approx(1.2459, abs=0.001)
 
     def test_retrieving_first_2_values_hkl_for_Fe(self):
-        """Assert the correct hkl first 2 values are returned for Fe"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        _hkl = _handler.hkl["Fe"]
-        self.assertEqual([1, 1, 0], _hkl[0])
-        self.assertEqual([2, 0, 0], _hkl[1])
-        self.assertEqual([2, 1, 1], _hkl[2])
-        self.assertEqual([2, 2, 0], _hkl[3])
+        """Correct hkl first 2 values are returned for Fe."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        hkl = handler.hkl["Fe"]
+        assert hkl[0] == [1, 1, 0]
+        assert hkl[1] == [2, 0, 0]
+        assert hkl[2] == [2, 1, 1]
+        assert hkl[3] == [2, 2, 0]
 
     def test_calculating_bragg_edges_for_Fe(self):
-        """Assert the first 3 bragg_edges are correct for Fe"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        _bragg_edges = _handler.bragg_edges["Fe"]
-        self.assertAlmostEqual(4.0537, _bragg_edges[0], delta=0.001)
-        self.assertAlmostEqual(2.8664, _bragg_edges[1], delta=0.001)
-        self.assertAlmostEqual(2.3404, _bragg_edges[2], delta=0.001)
+        """First 3 bragg_edges are correct for Fe."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        bragg_edges = handler.bragg_edges["Fe"]
+        assert bragg_edges[0] == pytest.approx(4.0537, abs=0.001)
+        assert bragg_edges[1] == pytest.approx(2.8664, abs=0.001)
+        assert bragg_edges[2] == pytest.approx(2.3404, abs=0.001)
 
     def test_printing_report(self):
-        """Assert the metadata/hkl/braggedges are correctly output"""
-        _handler = BraggEdge(material="Ni", number_of_bragg_edges=5)
+        """metadata/hkl/braggedges are correctly output."""
+        # Just verify no exception is raised
+        BraggEdge(material="Ni", number_of_bragg_edges=5)
 
     def test_create_export_csv_no_file_raise_error(self):
-        """Assert the IOError is raised when no file name given"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        self.assertRaises(IOError, _handler.export)
+        """IOError is raised when no file name given."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        with pytest.raises(IOError):
+            handler.export()
 
     def test_create_export_csv_metadata(self):
-        """Assert the correct metadata data are created for Fe when using create output file"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        _metadata = _handler._format_metadata("Fe")
-        self.assertEqual("Material: Fe", _metadata[0])
-        self.assertEqual("Lattice : 2.8664Angstroms", _metadata[1])
-        self.assertEqual("Crystal Structure: BCC", _metadata[2])
-        self.assertEqual("Using local metadata Table: True", _metadata[3])
+        """Correct metadata data are created for Fe when using create output file."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        metadata = handler._format_metadata("Fe")
+        assert metadata[0] == "Material: Fe"
+        assert metadata[1] == "Lattice : 2.8664Angstroms"
+        assert metadata[2] == "Crystal Structure: BCC"
+        assert metadata[3] == "Using local metadata Table: True"
 
     def test_create_export_csv_data(self):
-        """Assert the correct data are created for Fe when using create output file"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        _data = _handler._format_data("Fe")
-        self.assertEqual(1, _data[0][0])
-        self.assertAlmostEqual(2.02685, _data[0][3], delta=0.0001)
-        self.assertAlmostEqual(4.05370, _data[0][4], delta=0.0001)
-        self.assertAlmostEqual(1.17020, _data[2][3], delta=0.0001)
-        self.assertAlmostEqual(2.34041, _data[2][4], delta=0.0001)
+        """Correct data are created for Fe when using create output file."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        data = handler._format_data("Fe")
+        assert data[0][0] == 1
+        assert data[0][3] == pytest.approx(2.02685, abs=0.0001)
+        assert data[0][4] == pytest.approx(4.05370, abs=0.0001)
+        assert data[2][3] == pytest.approx(1.17020, abs=0.0001)
+        assert data[2][4] == pytest.approx(2.34041, abs=0.0001)
 
-    def test_create_export_csv_file_created(self):
-        """Assert the correct output CSV file is created"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        _filename = "remove_me.txt"
-        _handler.export(filename=_filename, file_type="csv")
-        self.assertTrue(os.path.isfile("remove_me_Fe.txt"))
-        os.remove("remove_me_Fe.txt")  # cleanup temp file
+    def test_create_export_csv_file_created(self, tmp_path):
+        """Correct output CSV file is created."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        filename = str(tmp_path / "test_output.txt")
+        handler.export(filename=filename, file_type="csv")
+        expected_file = tmp_path / "test_output_Fe.txt"
+        assert expected_file.is_file()
 
     def test_create_export_unsuported_file_raise_error(self):
-        """Assert in BraggEdge - NotImplementedError raised when trying to create unsuported output format"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        _filename = "remove_me_Fe.txt"
-        self.assertRaises(NotImplementedError, _handler.export, _filename, "do_not_exist_yet")
+        """NotImplementedError raised when trying to create unsupported output format."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        filename = "remove_me_Fe.txt"
+        with pytest.raises(NotImplementedError):
+            handler.export(filename, "do_not_exist_yet")
 
     def test_calculate_experimental_lattice_with_no_input_provided(self):
-        """Assert ValueError raised if no experimental bragg edge array provided."""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
-        self.assertRaises(ValueError, _handler.get_experimental_lattice_parameter)
+        """ValueError raised if no experimental bragg edge array provided."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        with pytest.raises(ValueError):
+            handler.get_experimental_lattice_parameter()
 
     def test_calculate_experimental_lattice_with_value_and_error_different_size(self):
-        """Assert in BraggEdge - bragg edge value and error have different sizes"""
-        _handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        """Bragg edge value and error have different sizes raises ValueError."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
         exp_bragg_value = np.array([1, 2, 3])
         exp_bragg_error = np.array([0.1, 0.2])
-        self.assertRaises(ValueError, _handler.get_experimental_lattice_parameter, exp_bragg_value, exp_bragg_error)
+        with pytest.raises(ValueError):
+            handler.get_experimental_lattice_parameter(exp_bragg_value, exp_bragg_error)
 
     def test_loading_single_material_in_list(self):
-        """Assert in BraggEdge - single element Al data listed in a list correctly caluclated"""
-        _handler = BraggEdge(material=["Al"], number_of_bragg_edges=4)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        """Single element Al data listed in a list correctly calculated."""
+        # Just verify no exception is raised
+        BraggEdge(material=["Al"], number_of_bragg_edges=4)

--- a/tests/neutronbraggedge/experiment_handler/experiment_test.py
+++ b/tests/neutronbraggedge/experiment_handler/experiment_test.py
@@ -45,11 +45,11 @@ class TestExperiment:
         tof_file = get_data_file("tof.txt")
         tof_obj = TOF(filename=tof_file)
         distance_source_detector_m = 1.609
-        detector_offset_s = 4500e-6
+        detector_offset_micros = 4500
         exp_obj = Experiment(
             tof=tof_obj.tof_array,
             distance_source_detector_m=distance_source_detector_m,
-            detector_offset_micros=detector_offset_s,
+            detector_offset_micros=detector_offset_micros,
         )
         assert exp_obj._h_over_MnLds == pytest.approx(2.45869e-7, abs=0.0001)
 

--- a/tests/neutronbraggedge/experiment_handler/experiment_test.py
+++ b/tests/neutronbraggedge/experiment_handler/experiment_test.py
@@ -1,66 +1,70 @@
-import os
-import unittest
+"""Tests for Experiment class."""
 
 import numpy as np
+import pytest
 
 from neutronbraggedge.experiment_handler.experiment import Experiment
 from neutronbraggedge.experiment_handler.lambda_wavelength import LambdaWavelength
 from neutronbraggedge.experiment_handler.tof import TOF
 
 
-class ExperimentTest(unittest.TestCase):
-    def setUp(self):
-        _file_path = os.path.dirname(__file__)
-        self.data_path = os.path.abspath(os.path.join(_file_path, "../../data"))
+class TestExperiment:
+    """Tests for experiment handling."""
 
     def test_experiment_value_error_when_no_tof_provided(self):
-        """Assert in experiemnt - that ValueError is raised when tof array is missing"""
-        self.assertRaises(ValueError, Experiment)
+        """ValueError is raised when tof array is missing."""
+        with pytest.raises(ValueError):
+            Experiment()
 
     def test_experiment_value_error_when_missing_argument_for_lambda_calculation(self):
-        """Assert ValueError raised when detector_offset or LDS are missing."""
-        _tof = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
-        self.assertRaises(ValueError, Experiment, _tof)
-        self.assertRaises(ValueError, Experiment, _tof, None, 1)
-        self.assertRaises(ValueError, Experiment, _tof, None, None, 2)
+        """ValueError raised when detector_offset or LDS are missing."""
+        tof = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+        with pytest.raises(ValueError):
+            Experiment(tof)
+        with pytest.raises(ValueError):
+            Experiment(tof, None, 1)
+        with pytest.raises(ValueError):
+            Experiment(tof, None, None, 2)
 
     def test_experiment_value_error_when_lambda_provided_and_either_lds_or_offset_missing(self):
-        """Assert in experiment - that ValueError is raised when LdS and offset are missing when lambda provided"""
-        _tof = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
-        _lambda = [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0]
-        self.assertRaises(ValueError, Experiment, _tof, _lambda)
+        """ValueError is raised when LdS and offset are missing when lambda provided."""
+        tof = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+        lambda_array = [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0]
+        with pytest.raises(ValueError):
+            Experiment(tof, lambda_array)
 
     def test_experiment_value_error_when_lambda_and_tof_not_same_size(self):
-        """Assert in experiment - that ValueError is raised when tof and lambda array do not have the same size"""
-        _tof = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
-        _lambda = [11.0, 12.0, 13.0, 14.0, 15.0]
-        self.assertRaises(ValueError, Experiment, _tof, _lambda, 10)
+        """ValueError is raised when tof and lambda array do not have the same size."""
+        tof = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+        lambda_array = [11.0, 12.0, 13.0, 14.0, 15.0]
+        with pytest.raises(ValueError):
+            Experiment(tof, lambda_array, 10)
 
-    def test_experiment_calculate_main_coefficient(self):
-        """Assert in experiment - the calculation of main coefficient is correct"""
-        _tof_file = os.path.join(self.data_path, "tof.txt")
-        _tof_obj = TOF(filename=_tof_file)
-        _distance_source_detector_m = 1.609
-        _detector_offset_s = 4500e-6
-        _exp_obj = Experiment(
-            tof=_tof_obj.tof_array,
-            distance_source_detector_m=_distance_source_detector_m,
-            detector_offset_micros=_detector_offset_s,
+    def test_experiment_calculate_main_coefficient(self, get_data_file):
+        """Calculation of main coefficient is correct."""
+        tof_file = get_data_file("tof.txt")
+        tof_obj = TOF(filename=tof_file)
+        distance_source_detector_m = 1.609
+        detector_offset_s = 4500e-6
+        exp_obj = Experiment(
+            tof=tof_obj.tof_array,
+            distance_source_detector_m=distance_source_detector_m,
+            detector_offset_micros=detector_offset_s,
         )
-        self.assertAlmostEqual(2.45869e-7, _exp_obj._h_over_MnLds, delta=0.0001)
+        assert exp_obj._h_over_MnLds == pytest.approx(2.45869e-7, abs=0.0001)
 
-    def test_experiment_calculate_lambda(self):
-        """Assert in experiment - the calculation of lambda is correct"""
-        _tof_file = os.path.join(self.data_path, "tof.txt")
-        _tof_obj = TOF(filename=_tof_file)
-        _distance_source_detector_m = 1.609
-        _detector_offset_micros = 4500
-        _exp_obj = Experiment(
-            tof=_tof_obj.tof_array,
-            distance_source_detector_m=_distance_source_detector_m,
-            detector_offset_micros=_detector_offset_micros,
+    def test_experiment_calculate_lambda(self, get_data_file):
+        """Calculation of lambda is correct."""
+        tof_file = get_data_file("tof.txt")
+        tof_obj = TOF(filename=tof_file)
+        distance_source_detector_m = 1.609
+        detector_offset_micros = 4500
+        exp_obj = Experiment(
+            tof=tof_obj.tof_array,
+            distance_source_detector_m=distance_source_detector_m,
+            detector_offset_micros=detector_offset_micros,
         )
-        _lambda_expected = np.array(
+        lambda_expected = np.array(
             [
                 1.10664704e-09,
                 1.10916474e-09,
@@ -84,77 +88,70 @@ class ExperimentTest(unittest.TestCase):
                 1.15448333e-09,
             ]
         )
-        _lambda_returned = _exp_obj.lambda_array
+        lambda_returned = exp_obj.lambda_array
         # Verify first 20 calculated lambda values match expected
-        self.assertAlmostEqual(_lambda_expected[0], _lambda_returned[0])
-        self.assertAlmostEqual(_lambda_expected[5], _lambda_returned[5])
-        self.assertAlmostEqual(_lambda_expected[19], _lambda_returned[19])
-        self.assertGreaterEqual(len(_lambda_returned), len(_lambda_expected))
+        assert lambda_expected[0] == pytest.approx(lambda_returned[0])
+        assert lambda_expected[5] == pytest.approx(lambda_returned[5])
+        assert lambda_expected[19] == pytest.approx(lambda_returned[19])
+        assert len(lambda_returned) >= len(lambda_expected)
 
-    def test_create_csv_lambda_file(self):
-        """Assert in Experiment - the lambda file is correctly exported"""
-        _tof_file = os.path.join(self.data_path, "tof.txt")
-        _tof_obj = TOF(filename=_tof_file)
-        _distance_source_detector_m = 1.609
-        _detector_offset_micros = 4500
-        _exp_obj = Experiment(
-            tof=_tof_obj.tof_array,
-            distance_source_detector_m=_distance_source_detector_m,
-            detector_offset_micros=_detector_offset_micros,
+    def test_create_csv_lambda_file(self, get_data_file, tmp_path):
+        """Lambda file is correctly exported."""
+        tof_file = get_data_file("tof.txt")
+        tof_obj = TOF(filename=tof_file)
+        distance_source_detector_m = 1.609
+        detector_offset_micros = 4500
+        exp_obj = Experiment(
+            tof=tof_obj.tof_array,
+            distance_source_detector_m=distance_source_detector_m,
+            detector_offset_micros=detector_offset_micros,
         )
-        _output_filename = os.path.join(self.data_path, "remove_me.txt")
-        _exp_obj.export_lambda(filename=_output_filename)
-        self.assertTrue(os.path.isfile(_output_filename))
-        os.remove(_output_filename)  # cleanup temp file
+        output_filename = tmp_path / "test_lambda.txt"
+        exp_obj.export_lambda(filename=str(output_filename))
+        assert output_filename.is_file()
 
-    def test_create_csv_lambda_file_without_providing_name(self):
-        """Assert in Experiment - no file is created if no filename is provided"""
-        _tof_file = os.path.join(self.data_path, "tof.txt")
-        _tof_obj = TOF(filename=_tof_file)
-        _distance_source_detector_m = 1.609
-        _detector_offset_micros = 4500
-        _output_file_name = os.path.join(self.data_path, "no_file.txt")
-        _exp_obj = Experiment(
-            tof=_tof_obj.tof_array,
-            distance_source_detector_m=_distance_source_detector_m,
-            detector_offset_micros=_detector_offset_micros,
+    def test_create_csv_lambda_file_without_providing_name(self, get_data_file):
+        """ValueError is raised if no filename is provided for export."""
+        tof_file = get_data_file("tof.txt")
+        tof_obj = TOF(filename=tof_file)
+        distance_source_detector_m = 1.609
+        detector_offset_micros = 4500
+        exp_obj = Experiment(
+            tof=tof_obj.tof_array,
+            distance_source_detector_m=distance_source_detector_m,
+            detector_offset_micros=detector_offset_micros,
         )
-        self.assertRaises(ValueError, _exp_obj.export_lambda)
+        with pytest.raises(ValueError):
+            exp_obj.export_lambda()
 
-    def test_calculate_distance_source_detector(self):
-        """Assert in Experiment - the distance source detector is corectly calculated"""
-        _tof_file = os.path.join(self.data_path, "tof.txt")
-        _tof_obj = TOF(filename=_tof_file)
-        _detector_offset_micros = 4500
-        _lambda_file = os.path.join(self.data_path, "lambda.txt")
-        _lambda_obj = LambdaWavelength(filename=_lambda_file)
-        _tof_array = _tof_obj.tof_array[0:20]
-        _lambda_array = _lambda_obj.lambda_array[0:20]
+    def test_calculate_distance_source_detector(self, get_data_file):
+        """Distance source detector is correctly calculated."""
+        tof_file = get_data_file("tof.txt")
+        tof_obj = TOF(filename=tof_file)
+        detector_offset_micros = 4500
+        lambda_file = get_data_file("lambda.txt")
+        lambda_obj = LambdaWavelength(filename=lambda_file)
+        tof_array = tof_obj.tof_array[0:20]
+        lambda_array = lambda_obj.lambda_array[0:20]
 
-        _exp_handler = Experiment(
-            tof=_tof_array, lambda_array=_lambda_array, detector_offset_micros=_detector_offset_micros
+        exp_handler = Experiment(
+            tof=tof_array, lambda_array=lambda_array, detector_offset_micros=detector_offset_micros
         )
-        _distance_expected = 1.609  # m
-        _distance_returned = _exp_handler.distance_source_detector
-        self.assertAlmostEqual(_distance_expected, _distance_returned, delta=1e-6)
+        distance_expected = 1.609  # m
+        assert exp_handler.distance_source_detector == pytest.approx(distance_expected, abs=1e-6)
 
-    def test_calculate_detector_offset(self):
-        """Assert in Experiment - the detector offset is correctly calculated"""
-        _tof_file = os.path.join(self.data_path, "tof.txt")
-        _tof_obj = TOF(filename=_tof_file)
-        _distance_source_detector_m = 1.609
-        _lambda_file = os.path.join(self.data_path, "lambda.txt")
-        _lambda_obj = LambdaWavelength(filename=_lambda_file)
-        _tof_array = _tof_obj.tof_array[0:20]
-        _lambda_array = _lambda_obj.lambda_array[0:20]
+    def test_calculate_detector_offset(self, get_data_file):
+        """Detector offset is correctly calculated."""
+        tof_file = get_data_file("tof.txt")
+        tof_obj = TOF(filename=tof_file)
+        distance_source_detector_m = 1.609
+        lambda_file = get_data_file("lambda.txt")
+        lambda_obj = LambdaWavelength(filename=lambda_file)
+        tof_array = tof_obj.tof_array[0:20]
+        lambda_array = lambda_obj.lambda_array[0:20]
 
-        _exp_handler = Experiment(
-            tof=_tof_array, lambda_array=_lambda_array, distance_source_detector_m=_distance_source_detector_m
+        exp_handler = Experiment(
+            tof=tof_array, lambda_array=lambda_array, distance_source_detector_m=distance_source_detector_m
         )
-        _offset_expected_micros = 4500  # micros
-        _offset_calculated = _exp_handler.detector_offset_micros
-        self.assertAlmostEqual(_offset_expected_micros, _offset_calculated, delta=1e-6)
-
-
-if __name__ == "__main__":
-    unittest.main()
+        offset_expected_micros = 4500  # micros
+        assert exp_handler.detector_offset_micros == pytest.approx(offset_expected_micros, abs=1e-6)

--- a/tests/neutronbraggedge/experiment_handler/lambda_test.py
+++ b/tests/neutronbraggedge/experiment_handler/lambda_test.py
@@ -1,67 +1,48 @@
-import os
-import unittest
+"""Tests for LambdaWavelength class."""
 
 import numpy as np
+import pytest
 
 from neutronbraggedge.experiment_handler.lambda_wavelength import LambdaWavelength
 
 
-class TofTest(unittest.TestCase):
-    def setUp(self):
-        _file_path = os.path.dirname(__file__)
-        self.data_path = os.path.abspath(os.path.join(_file_path, "../../data"))
+class TestLambdaWavelength:
+    """Tests for lambda wavelength handling."""
 
     def test_loading_manual_lambda_array(self):
-        """Assert in LambdaWavelength - manual loading of array"""
-        _lambda_array = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
-        _lambda_handler = LambdaWavelength(data=_lambda_array)
-        self.assertTrue(all(_lambda_array == _lambda_handler.lambda_array))
+        """Manual loading of array."""
+        lambda_array = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        lambda_handler = LambdaWavelength(data=lambda_array)
+        assert all(lambda_array == lambda_handler.lambda_array)
 
     def test_loading_normal_array_data(self):
-        """Assert in LambdaWavelength - loading of np.array array"""
-        _lambda_array = np.array([1, 2.0, 3.0, 4.0])
-        _lambda_handler = LambdaWavelength(data=_lambda_array)
-        self.assertTrue(all(_lambda_array == _lambda_handler.lambda_array))
+        """Loading of np.array array."""
+        lambda_array = np.array([1, 2.0, 3.0, 4.0])
+        lambda_handler = LambdaWavelength(data=lambda_array)
+        assert all(lambda_array == lambda_handler.lambda_array)
 
     def test_not_lambda_array_provided(self):
-        """Assert in LambdaWavelength - no lambda array provided"""
-        self.assertRaises(ValueError, LambdaWavelength)
+        """No lambda array provided raises ValueError."""
+        with pytest.raises(ValueError):
+            LambdaWavelength()
 
-    def test_loading_auto_lambda_array(self):
-        """Assert in LambdaWavelength - auto loading of array"""
-        _lambda_filename = os.path.join(self.data_path, "lambda.txt")
-        _lambda_handler = LambdaWavelength(filename=_lambda_filename)
-        _lambda_expected = np.array(
+    def test_loading_auto_lambda_array(self, get_data_file):
+        """Auto loading of array from file."""
+        lambda_filename = get_data_file("lambda.txt")
+        lambda_handler = LambdaWavelength(filename=lambda_filename)
+        lambda_expected = np.array(
             [
                 1.10664703784e-09,
                 1.10916473754e-09,
                 1.11168243725e-09,
                 1.11420013696e-09,
                 1.11671783666e-09,
-                1.11923553637e-09,
-                1.12175323607e-09,
-                1.12427093578e-09,
-                1.12678863549e-09,
-                1.12930633519e-09,
-                1.1318240349e-09,
-                1.1343417346e-09,
-                1.13685943431e-09,
-                1.13937713401e-09,
-                1.14189483372e-09,
-                1.14441253343e-09,
-                1.14693023313e-09,
-                1.14944793284e-09,
-                1.15196563254e-09,
-                1.15448333225e-09,
             ]
         )
-        self.assertTrue(all(_lambda_expected[0:5] == _lambda_handler.lambda_array[0:5]))
+        assert all(lambda_expected == lambda_handler.lambda_array[0:5])
 
-    def test_load_bad_file_name(self):
-        """Assert in LambdaWavelength - file name is provided but does not exist"""
-        _lambda_filename = os.path.join(self.data_path, "i_do_not_exist.txt")
-        self.assertRaises(IOError, LambdaWavelength, _lambda_filename)
-
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_load_bad_file_name(self, get_data_file):
+        """File name is provided but does not exist raises IOError."""
+        lambda_filename = get_data_file("i_do_not_exist.txt")
+        with pytest.raises(IOError):
+            LambdaWavelength(lambda_filename)

--- a/tests/neutronbraggedge/experiment_handler/tof_test.py
+++ b/tests/neutronbraggedge/experiment_handler/tof_test.py
@@ -1,108 +1,96 @@
-import os
-import unittest
+"""Tests for TOF class."""
 
 import numpy as np
+import pytest
 
 from neutronbraggedge.experiment_handler.tof import TOF
 
 
-class TofTest(unittest.TestCase):
-    def setUp(self):
-        _file_path = os.path.dirname(__file__)
-        self.data_path = os.path.abspath(os.path.join(_file_path, "../../data"))
-
-    def get_full_path(self, file_name):
-        return os.path.join(self.data_path, file_name)
+class TestTOF:
+    """Tests for Time-of-Flight handling."""
 
     def test_loading_manual_tof_in_s_units(self):
-        """Assert in TOF - TOF(s) array is correctly manually loaded"""
-        _tof_array = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
-        _tof_handler = TOF(tof_array=_tof_array)
-        self.assertTrue(all(_tof_array == _tof_handler.tof_array))
+        """TOF(s) array is correctly manually loaded."""
+        tof_array = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+        tof_handler = TOF(tof_array=tof_array)
+        assert all(tof_array == tof_handler.tof_array)
 
     def test_loading_manual_tof_raise_error_if_no_data_provided(self):
-        """Assert in TOF - that ValueError is raised if not tof array provided"""
-        self.assertRaises(ValueError, TOF)
+        """ValueError is raised if no tof array provided."""
+        with pytest.raises(ValueError):
+            TOF()
 
-    def test_loading_file_raise_error_if_file_does_not_exist(self):
-        """Assert in TOF - that IOError is raised when file does not exist"""
-        _filename = self.get_full_path("fake_tof.txt")
-        self.assertRaises(IOError, TOF, _filename)
+    def test_loading_file_raise_error_if_file_does_not_exist(self, get_data_file):
+        """IOError is raised when file does not exist."""
+        filename = get_data_file("fake_tof.txt")
+        with pytest.raises(IOError):
+            TOF(filename)
 
     def test_loading_manual_tof_in_micros_units(self):
-        """Assert in TOF - TOF(micros) array is correctly manually loaded and units are converted"""
-        _tof_array = np.array([1.0e6, 2.0e6, 3.0e6, 4.0e6, 5.0e6, 6.0e6, 7.0e6, 8.0e6, 9.0e6])
-        _tof_units = "micros"
-        _tof_handler = TOF(tof_array=_tof_array, units=_tof_units)
-        self.assertTrue(all(_tof_array * 1.0e-6 == _tof_handler.tof_array))
+        """TOF(micros) array is correctly manually loaded and units are converted."""
+        tof_array = np.array([1.0e6, 2.0e6, 3.0e6, 4.0e6, 5.0e6, 6.0e6, 7.0e6, 8.0e6, 9.0e6])
+        tof_units = "micros"
+        tof_handler = TOF(tof_array=tof_array, units=tof_units)
+        assert all(tof_array * 1.0e-6 == tof_handler.tof_array)
 
     def test_loading_manual_tof_in_ms_units(self):
-        """Assert in TOF - TOF(ms) array is correctly manually loaded and units are converted"""
-        _tof_array = np.array([1.0e3, 2.0e3, 3.0e3, 4.0e3, 5.0e3, 6.0e3, 7.0e3, 8.0e3, 9.0e3])
-        _tof_units = "ms"
-        _tof_handler = TOF(tof_array=_tof_array, units=_tof_units)
-        self.assertTrue(all(_tof_array * 1.0e-3 == _tof_handler.tof_array))
+        """TOF(ms) array is correctly manually loaded and units are converted."""
+        tof_array = np.array([1.0e3, 2.0e3, 3.0e3, 4.0e3, 5.0e3, 6.0e3, 7.0e3, 8.0e3, 9.0e3])
+        tof_units = "ms"
+        tof_handler = TOF(tof_array=tof_array, units=tof_units)
+        assert all(tof_array * 1.0e-3 == tof_handler.tof_array)
 
     def test_loading_manual_tof_in_ns_units(self):
-        """Assert in TOF - TOF(ms) array is correctly manually loaded and units are converted"""
-        _tof_array = np.array([1.0e9, 2.0e9, 3.0e9, 4.0e9, 5.0e9, 6.0e9, 7.0e9, 8.0e9, 9.0e9])
-        _tof_units = "ns"
-        _tof_handler = TOF(tof_array=_tof_array, units=_tof_units)
-        self.assertTrue(all(_tof_array * 1.0e-9 == _tof_handler.tof_array))
+        """TOF(ns) array is correctly manually loaded and units are converted."""
+        tof_array = np.array([1.0e9, 2.0e9, 3.0e9, 4.0e9, 5.0e9, 6.0e9, 7.0e9, 8.0e9, 9.0e9])
+        tof_units = "ns"
+        tof_handler = TOF(tof_array=tof_array, units=tof_units)
+        assert all(tof_array * 1.0e-9 == tof_handler.tof_array)
 
     def test_loading_manual_tof_units_not_implemented_yet(self):
-        """Assert in TOF - that an error is thrown when the units is not recognized"""
-        _tof_array = np.array([1.0e9, 2.0e9, 3.0e9, 4.0e9, 5.0e9, 6.0e9, 7.0e9, 8.0e9, 9.0e9])
-        _tof_units = "crazys"
-        self.assertRaises(ValueError, TOF, tof_array=_tof_array, units=_tof_units)
+        """Error is thrown when the units is not recognized."""
+        tof_array = np.array([1.0e9, 2.0e9, 3.0e9, 4.0e9, 5.0e9, 6.0e9, 7.0e9, 8.0e9, 9.0e9])
+        tof_units = "crazys"
+        with pytest.raises(ValueError):
+            TOF(tof_array=tof_array, units=tof_units)
 
-    def test_loading_good_tof_file(self):
-        """Assert in TOF - that correctly formated tof file is correctly loaded"""
-        _filename = self.get_full_path("good_tof.txt")
-        _tof_handler = TOF(filename=_filename)
-        _tof_expected = np.array([1.0, 2.0, 3.0, 4.0])
-        self.assertTrue(all(_tof_expected == _tof_handler.tof_array[0:4]))
+    def test_loading_good_tof_file(self, get_data_file):
+        """Correctly formatted tof file is correctly loaded."""
+        filename = get_data_file("good_tof.txt")
+        tof_handler = TOF(filename=filename)
+        tof_expected = np.array([1.0, 2.0, 3.0, 4.0])
+        assert all(tof_expected == tof_handler.tof_array[0:4])
 
-    def test_loading_real_tof_file(self):
-        """Assert in TOF - that real tof file is correctly loaded"""
-        _filename = self.get_full_path("tof.txt")
-        _tof_handler = TOF(filename=_filename)
-        _tof_expected = np.array([9.6e-7, 1.12e-5, 2.144e-5, 3.168e-5])
-        self.assertTrue(all(_tof_expected == _tof_handler.tof_array[0:4]))
+    def test_loading_real_tof_file(self, get_data_file):
+        """Real tof file is correctly loaded."""
+        filename = get_data_file("tof.txt")
+        tof_handler = TOF(filename=filename)
+        tof_expected = np.array([9.6e-7, 1.12e-5, 2.144e-5, 3.168e-5])
+        assert all(tof_expected == tof_handler.tof_array[0:4])
 
-    def test_loading_counts_column(self):
-        """Assert in TOF - second column (counts) is correctly loaded"""
-        _filename = self.get_full_path("tof.txt")
-        _tof_handler = TOF(filename=_filename)
-        _counts_expected = np.array([2137, 1988, 1979, 2078])
-        print(_counts_expected)
-        print(_tof_handler.counts_array[0:4])
-        self.assertTrue(all(_counts_expected == _tof_handler.counts_array[0:4]))
+    def test_loading_counts_column(self, get_data_file):
+        """Second column (counts) is correctly loaded."""
+        filename = get_data_file("tof.txt")
+        tof_handler = TOF(filename=filename)
+        counts_expected = np.array([2137, 1988, 1979, 2078])
+        assert all(counts_expected == tof_handler.counts_array[0:4])
 
-    def test_loading_second_ascii_format(self):
-        """assert tof2 can be loaded, columns are white spaced"""
-        _filename = self.get_full_path("tof2.txt")
-        _tof_handler = TOF(filename=_filename)
-        _counts_expected = np.array([9120595, 10638008, 12523304, 14676656])
+    def test_loading_second_ascii_format(self, get_data_file):
+        """Tof2 can be loaded, columns are white spaced."""
+        filename = get_data_file("tof2.txt")
+        tof_handler = TOF(filename=filename)
+        counts_expected = np.array([9120595, 10638008, 12523304, 14676656])
+        assert all(counts_expected == tof_handler.counts_array[0:4])
 
-        print(_counts_expected)
-        print(_tof_handler.counts_array[0:4])
+        tof_expected = np.array([1.136e-05, 2.16e-05, 3.184e-05, 4.208e-05])
+        assert all(tof_expected == tof_handler.tof_array[0:4])
 
-        self.assertTrue(all(_counts_expected == _tof_handler.counts_array[0:4]))
+    def test_loading_third_ascii_format(self, get_data_file):
+        """Tof3 can be loaded, columns are white spaced."""
+        filename = get_data_file("tof3.txt")
+        tof_handler = TOF(filename=filename)
+        counts_expected = np.array([9120595, 10638008, 12523304, 14676656])
+        assert all(counts_expected == tof_handler.counts_array[0:4])
 
-        _tof_expected = np.array([1.136e-05, 2.16e-05, 3.184e-05, 4.208e-05])
-        self.assertTrue(all(_tof_expected == _tof_handler.tof_array[0:4]))
-
-    def test_loading_third_ascii_format(self):
-        """assert tof3 can be loaded, columns are white spaced"""
-        _filename = self.get_full_path("tof3.txt")
-        _tof_handler = TOF(filename=_filename)
-        _counts_expected = np.array([9120595, 10638008, 12523304, 14676656])
-        self.assertTrue(all(_counts_expected == _tof_handler.counts_array[0:4]))
-
-        _tof_expected = np.array([1.136e-05, 2.16e-05, 3.184e-05, 4.208e-05])
-        self.assertTrue(all(_tof_expected == _tof_handler.tof_array[0:4]))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        tof_expected = np.array([1.136e-05, 2.16e-05, 3.184e-05, 4.208e-05])
+        assert all(tof_expected == tof_handler.tof_array[0:4])

--- a/tests/neutronbraggedge/lattice_handler/lattice_test.py
+++ b/tests/neutronbraggedge/lattice_handler/lattice_test.py
@@ -1,163 +1,131 @@
+"""Tests for Lattice class."""
+
 import math
-import unittest
 
 import numpy as np
+import pytest
 
 from neutronbraggedge.lattice_handler.lattice import Lattice
 
 
-class TestLattice(unittest.TestCase):
-    def setUp(self):
-        pass
+class TestLattice:
+    """Tests for lattice handling functionality."""
 
     def test_lattice_error_when_bad_structure_given(self):
-        """Assert in Lattice - Value Error is raised when bad structure given"""
-        _crystal_structure = "FakeStructure"
-        self.assertRaises(ValueError, Lattice, None, _crystal_structure)
+        """Value Error is raised when bad structure given."""
+        crystal_structure = "FakeStructure"
+        with pytest.raises(ValueError):
+            Lattice(None, crystal_structure)
 
     def test_correctly_hkl_returned_for_Si_3entries(self):
-        """Assert in Lattice - hkl array correctly calculated and reported for 3 entries"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1, 2, 3])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
-        _hkl_expected = [[1, 1, 1], [2, 0, 0], [2, 2, 0]]
-        self.assertTrue(o_lattice.hkl == _hkl_expected)
-
-    # def test_bragg_edge_correctly_formated_with_none_value(self):
-    # """Assert in Lattice - bragg edge array correctly formated with None values"""
-    # _material = 'Si'
-    # _crystal_structure = 'FCC'
-    # _bragg_edge_array = np.array([1, None, 3])
-    # o_lattice = Lattice(material = _material,
-    # crystal_structure = _crystal_structure,
-    # bragg_edge_array = _bragg_edge_array)
-    # _bragg_edge_array_expected = [1, np.NAN, 3]
-    # self.assertEqual(_bragg_edge_array_expected, o_lattice.bragg_edge_array)
+        """hkl array correctly calculated and reported for 3 entries."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1, 2, 3])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
+        hkl_expected = [[1, 1, 1], [2, 0, 0], [2, 2, 0]]
+        assert o_lattice.hkl == hkl_expected
 
     def test_correctly_hkl_returned_for_Si_4entries_with_None(self):
-        """Assert in Lattice - hkl array correctly calculated and reported for 4 entries with None"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1, 2, None, 3])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
-        _hkl_expected = [[1, 1, 1], [2, 0, 0], [2, 2, 0], [2, 2, 2]]
-        self.assertTrue(o_lattice.hkl == _hkl_expected)
+        """hkl array correctly calculated and reported for 4 entries with None."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1, 2, None, 3])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
+        hkl_expected = [[1, 1, 1], [2, 0, 0], [2, 2, 0], [2, 2, 2]]
+        assert o_lattice.hkl == hkl_expected
 
     def test_bragg_edge_crystal_structure_correctly_created(self):
-        """Assert in Lattice - bragg edge crystal structure correctly created"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
+        """Bragg edge crystal structure correctly created."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
         o_lattice._match_bragg_edge_with_hkl()
 
-        _expected_first_key = [1, 1, 1]
-        _expected_first_value = 1.1
-        self.assertEqual(_expected_first_key, o_lattice.hkl_bragg_edge[0][0])
-        self.assertEqual(_expected_first_value, o_lattice.hkl_bragg_edge[0][1])
+        expected_first_key = [1, 1, 1]
+        expected_first_value = 1.1
+        assert o_lattice.hkl_bragg_edge[0][0] == expected_first_key
+        assert o_lattice.hkl_bragg_edge[0][1] == expected_first_value
 
-        _expected_second_key = [2, 0, 0]
-        _expected_second_value = 2.2
-        self.assertEqual(_expected_second_key, o_lattice.hkl_bragg_edge[1][0])
-        self.assertEqual(_expected_second_value, o_lattice.hkl_bragg_edge[1][1])
+        expected_second_key = [2, 0, 0]
+        expected_second_value = 2.2
+        assert o_lattice.hkl_bragg_edge[1][0] == expected_second_key
+        assert o_lattice.hkl_bragg_edge[1][1] == expected_second_value
 
     def test_bragg_edge_crystal_structure_correctly_created_for_incomplete_list(self):
-        """Assert in Lattice - bragg edge crystal structure correctly created for incomplete list"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1.1, None, None, 4.4])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
+        """Bragg edge crystal structure correctly created for incomplete list."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1.1, None, None, 4.4])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
         o_lattice._match_bragg_edge_with_hkl()
 
-        _expected_first_key = [1, 1, 1]
-        _expected_first_value = 1.1
-        self.assertEqual(_expected_first_key, o_lattice.hkl_bragg_edge[0][0])
-        self.assertEqual(_expected_first_value, o_lattice.hkl_bragg_edge[0][1])
+        expected_first_key = [1, 1, 1]
+        expected_first_value = 1.1
+        assert o_lattice.hkl_bragg_edge[0][0] == expected_first_key
+        assert o_lattice.hkl_bragg_edge[0][1] == expected_first_value
 
-        _expected_second_key = [2, 0, 0]
-        _expected_second_value = np.nan
-        self.assertEqual(_expected_second_key, o_lattice.hkl_bragg_edge[1][0])
-        self.assertTrue(math.isnan(o_lattice.hkl_bragg_edge[1][1]))
+        expected_second_key = [2, 0, 0]
+        assert o_lattice.hkl_bragg_edge[1][0] == expected_second_key
+        assert math.isnan(o_lattice.hkl_bragg_edge[1][1])
 
     def test_hkl_bragg_edge_correctly_displayed(self):
-        """Assert in Lattice - hkl bragg edge correctly displayed"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
+        """hkl bragg edge correctly displayed."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
         o_lattice._match_bragg_edge_with_hkl()
-        self.assertTrue(o_lattice.display_hkl_bragg_edge())
+        assert o_lattice.display_hkl_bragg_edge()
 
     def test_lattice_coefficient_correctly_calculated(self):
-        """Assert in Lattice - lattice coefficient correctly calculated for [1,1,1]"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
+        """Lattice coefficient correctly calculated for [1,1,1]."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
         o_lattice._match_bragg_edge_with_hkl()
         o_lattice._calculate_lattice_array()
-        self.assertEqual(len(_bragg_edge_array), len(o_lattice.lattice_array))
-        self.assertAlmostEqual(0.952628, o_lattice.lattice_array[0], delta=0.00001)
+        assert len(bragg_edge_array) == len(o_lattice.lattice_array)
+        assert o_lattice.lattice_array[0] == pytest.approx(0.952628, abs=0.00001)
 
     def test_lattice_statistics(self):
-        """Assert in Lattice - lattice statistics correctly calculated for Si"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
+        """Lattice statistics correctly calculated for Si."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
         o_lattice._match_bragg_edge_with_hkl()
         o_lattice._calculate_lattice_array()
         o_lattice._calculate_lattice_statistics()
-        _statistics = o_lattice.lattice_statistics
+        statistics = o_lattice.lattice_statistics
 
-        _delta = 1e-4
-        self.assertAlmostEqual(2.549745, _statistics["std"], delta=_delta)
-        self.assertAlmostEqual(0.952628, _statistics["min"], delta=_delta)
-        self.assertAlmostEqual(7.621024, _statistics["max"], delta=_delta)
-        self.assertAlmostEqual(3.433452, _statistics["median"], delta=_delta)
-        self.assertAlmostEqual(3.860139, _statistics["mean"][0], delta=_delta)
+        delta = 1e-4
+        assert statistics["std"] == pytest.approx(2.549745, abs=delta)
+        assert statistics["min"] == pytest.approx(0.952628, abs=delta)
+        assert statistics["max"] == pytest.approx(7.621024, abs=delta)
+        assert statistics["median"] == pytest.approx(3.433452, abs=delta)
+        assert statistics["mean"][0] == pytest.approx(3.860139, abs=delta)
 
     def test_display_statistics(self):
-        """Assert in Lattice - lattice statistics correctly displayed for Si"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
+        """Lattice statistics correctly displayed for Si."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
         o_lattice._match_bragg_edge_with_hkl()
         o_lattice._calculate_lattice_array()
         o_lattice._calculate_lattice_statistics()
         o_lattice.display_lattice_statistics()
 
     def test_display_recap(self):
-        """Assert in Lattice - lattice recap displayed correctly"""
-        _material = "Si"
-        _crystal_structure = "FCC"
-        _bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
-        o_lattice = Lattice(
-            material=_material, crystal_structure=_crystal_structure, bragg_edge_array=_bragg_edge_array
-        )
+        """Lattice recap displayed correctly."""
+        material = "Si"
+        crystal_structure = "FCC"
+        bragg_edge_array = np.array([1.1, 2.2, 3.3, 4.4])
+        o_lattice = Lattice(material=material, crystal_structure=crystal_structure, bragg_edge_array=bragg_edge_array)
         o_lattice._match_bragg_edge_with_hkl()
         o_lattice._calculate_lattice_array()
         o_lattice._calculate_lattice_statistics()
         o_lattice.display_recap()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/neutronbraggedge/material_handler/retrieve_material_metadata_test.py
+++ b/tests/neutronbraggedge/material_handler/retrieve_material_metadata_test.py
@@ -1,42 +1,41 @@
-import unittest
+"""Tests for RetrieveMaterialMetadata class."""
+
+import pytest
 
 from neutronbraggedge.material_handler.retrieve_material_metadata import RetrieveMaterialMetadata
 
 
-class TestRetrieveMaterialMetadata(unittest.TestCase):
-    def setUp(self):
-        pass
+class TestRetrieveMaterialMetadata:
+    """Tests for retrieving material metadata from local and web sources."""
 
     def test_retrieve_lattice_of_si_via_web(self):
-        """Assert in RetrieveMaterialMetadata - value of lattice retrieved from Si via web table"""
+        """Value of lattice retrieved from Si via web table."""
         retrieve_material = RetrieveMaterialMetadata(material="Si", use_local_table=False)
         lattice_expected = 5.431
-        self.assertAlmostEqual(lattice_expected, retrieve_material.lattice, delta=0.001)
+        assert retrieve_material.lattice == pytest.approx(lattice_expected, abs=0.001)
 
     def test_retrieve_lattice_of_si_via_local_table(self):
-        """Assert in RetrieveMaterialMetadata - value of lattice retrieved from Si via local table"""
+        """Value of lattice retrieved from Si via local table."""
         retrieve_material = RetrieveMaterialMetadata(material="Si", use_local_table=True)
         lattice_expected = 5.431591  # higher precision on local table
-        self.assertEqual(lattice_expected, retrieve_material.lattice)
+        assert retrieve_material.lattice == lattice_expected
 
-    def test_raise_NameError_no_arguments(self):
-        """Assert in RetrieveMaterialMetadata - NameError is raised when no arguments is given"""
-        self.assertRaises(NameError, RetrieveMaterialMetadata)
+    def test_raise_name_error_no_arguments(self):
+        """NameError is raised when no arguments is given."""
+        with pytest.raises(NameError):
+            RetrieveMaterialMetadata()
 
-    def test_raise_NameError_material_unknown(self):
-        """Assert in RetrieveMaterialMetadata - NameError is raised if material is unknown"""
-        self.assertRaises(KeyError, RetrieveMaterialMetadata, "unknown")
+    def test_raise_key_error_material_unknown(self):
+        """KeyError is raised if material is unknown."""
+        with pytest.raises(KeyError):
+            RetrieveMaterialMetadata("unknown")
 
     def test_retrieving_full_list_of_material(self):
-        """Assert in RetrieveMaterialMetadata - Full list of material available returned"""
+        """Full list of material available returned."""
         retrieve_material = RetrieveMaterialMetadata(material="all", use_local_table=False)
 
         list_returned = retrieve_material.full_list_material()
         # Check that expected materials are present (Wikipedia content may change order)
         expected_materials = ["C (diamond)", "Si", "Ge"]
         for material in expected_materials:
-            self.assertIn(material, list_returned)
-
-
-if __name__ == "__main__":
-    unittest.main()
+            assert material in list_returned

--- a/tests/neutronbraggedge/material_handler/retrieve_metadata_table_test.py
+++ b/tests/neutronbraggedge/material_handler/retrieve_metadata_table_test.py
@@ -1,44 +1,34 @@
-import os
-import unittest
+"""Tests for RetrieveMetadataTable class."""
 
 import pytest
 
-from neutronbraggedge import config
 from neutronbraggedge.material_handler.retrieve_metadata_table import RetrieveMetadataTable
 
 
-class TestRetrieveMetadataTable(unittest.TestCase):
-    def setUp(self):
-        _config_file = config.config_file
-        self._config_file = os.path.abspath(_config_file)
+class TestRetrieveMetadataTable:
+    """Tests for retrieving metadata tables."""
 
     @pytest.mark.skip(reason="Not using the url database right now")
     def test_retrieve_table_from_url(self):
-        """checking if the table is correctly loaded from URL"""
-
+        """Check if the table is correctly loaded from URL."""
         retrieve_meta = RetrieveMetadataTable(use_local_table=False)
-        _table = retrieve_meta.get_table()
-        _shape = _table.shape
+        table = retrieve_meta.get_table()
+        shape = table.shape
 
         nbr_column = 3
-        self.assertEqual(_shape[1], nbr_column)
+        assert shape[1] == nbr_column
 
         value_0_0 = "Diamond (FCC)"
-        self.assertEqual(value_0_0, _table.values[0][1])
+        assert table.values[0][1] == value_0_0
 
     def test_retrieve_local_table(self):
-        """checking if the local table is correctly loaded"""
-
+        """Check if the local table is correctly loaded."""
         retrieve_meta = RetrieveMetadataTable()
-        _table = retrieve_meta.get_table()
-        _shape = _table.shape
+        table = retrieve_meta.get_table()
+        shape = table.shape
 
         nbr_column = 3
-        self.assertEqual(_shape[1], nbr_column)
+        assert shape[1] == nbr_column
 
         value_0_0 = "Diamond (FCC)"
-        self.assertEqual(value_0_0, _table.values[0][1])
-
-
-if __name__ == "__main__":
-    unittest.main()
+        assert table.values[0][1] == value_0_0

--- a/tests/neutronbraggedge/utilities_test.py
+++ b/tests/neutronbraggedge/utilities_test.py
@@ -1,144 +1,149 @@
-import os
-import unittest
+"""Tests for Utilities class."""
 
 import numpy as np
+import pytest
 
 from neutronbraggedge.utilities import Utilities
 
 
-class UtilitiesTest(unittest.TestCase):
-    def setUp(self):
-        _file_path = os.path.dirname(__file__)
-        self.data_path = os.path.abspath(os.path.join(_file_path, "../data"))
-
-    def get_full_path(self, file_name):
-        return os.path.join(self.data_path, file_name)
+class TestUtilities:
+    """Tests for utility functions."""
 
     def test_convert_time_units_raise_value_error_when_no_data_provided(self):
-        """Assert in utilities - ValueError raised when no data provided"""
-        self.assertRaises(ValueError, Utilities.convert_time_units)
+        """ValueError raised when no data provided."""
+        with pytest.raises(ValueError):
+            Utilities.convert_time_units()
 
     def test_convert_time_units_raise_value_error_when_units_not_supported(self):
-        """Assert in utilities - ValueError raised when no units converted"""
-        self.assertRaises(ValueError, Utilities.convert_time_units, 45, "bad_units", "s")
-        self.assertRaises(ValueError, Utilities.convert_time_units, 45, "s", "bad_units")
-        self.assertRaises(ValueError, Utilities.convert_time_units, 45, "bad_units", "bad_units")
+        """ValueError raised when units not supported."""
+        with pytest.raises(ValueError):
+            Utilities.convert_time_units(45, "bad_units", "s")
+        with pytest.raises(ValueError):
+            Utilities.convert_time_units(45, "s", "bad_units")
+        with pytest.raises(ValueError):
+            Utilities.convert_time_units(45, "bad_units", "bad_units")
 
     def test_get_time_conversion_coeff(self):
-        """Assert in utilities - correct time coefficient are returned"""
-        self.assertEqual(1, Utilities.get_time_conversion_coeff(from_units="s", to_units="s"))
-        self.assertEqual(1.0e3, Utilities.get_time_conversion_coeff(from_units="s", to_units="ms"))
-        self.assertEqual(1.0e6, Utilities.get_time_conversion_coeff(from_units="s", to_units="micros"))
-        self.assertEqual(1.0e9, Utilities.get_time_conversion_coeff(from_units="s", to_units="ns"))
+        """Correct time coefficients are returned."""
+        assert Utilities.get_time_conversion_coeff(from_units="s", to_units="s") == 1
+        assert Utilities.get_time_conversion_coeff(from_units="s", to_units="ms") == 1.0e3
+        assert Utilities.get_time_conversion_coeff(from_units="s", to_units="micros") == 1.0e6
+        assert Utilities.get_time_conversion_coeff(from_units="s", to_units="ns") == 1.0e9
 
-        self.assertEqual(1.0e-3, Utilities.get_time_conversion_coeff(from_units="ms", to_units="s"))
-        self.assertEqual(1, Utilities.get_time_conversion_coeff(from_units="ms", to_units="ms"))
-        self.assertEqual(1e3, Utilities.get_time_conversion_coeff(from_units="ms", to_units="micros"))
-        self.assertEqual(1e6, Utilities.get_time_conversion_coeff(from_units="ms", to_units="ns"))
+        assert Utilities.get_time_conversion_coeff(from_units="ms", to_units="s") == 1.0e-3
+        assert Utilities.get_time_conversion_coeff(from_units="ms", to_units="ms") == 1
+        assert Utilities.get_time_conversion_coeff(from_units="ms", to_units="micros") == 1e3
+        assert Utilities.get_time_conversion_coeff(from_units="ms", to_units="ns") == 1e6
 
-        self.assertEqual(1.0e-6, Utilities.get_time_conversion_coeff(from_units="micros", to_units="s"))
-        self.assertEqual(1.0e-3, Utilities.get_time_conversion_coeff(from_units="micros", to_units="ms"))
-        self.assertEqual(1, Utilities.get_time_conversion_coeff(from_units="micros", to_units="micros"))
-        self.assertEqual(1e3, Utilities.get_time_conversion_coeff(from_units="micros", to_units="ns"))
+        assert Utilities.get_time_conversion_coeff(from_units="micros", to_units="s") == 1.0e-6
+        assert Utilities.get_time_conversion_coeff(from_units="micros", to_units="ms") == 1.0e-3
+        assert Utilities.get_time_conversion_coeff(from_units="micros", to_units="micros") == 1
+        assert Utilities.get_time_conversion_coeff(from_units="micros", to_units="ns") == 1e3
 
-        self.assertEqual(1e-9, Utilities.get_time_conversion_coeff(from_units="ns", to_units="s"))
-        self.assertEqual(1e-6, Utilities.get_time_conversion_coeff(from_units="ns", to_units="ms"))
-        self.assertEqual(1e-3, Utilities.get_time_conversion_coeff(from_units="ns", to_units="micros"))
-        self.assertEqual(1, Utilities.get_time_conversion_coeff(from_units="ns", to_units="ns"))
+        assert Utilities.get_time_conversion_coeff(from_units="ns", to_units="s") == 1e-9
+        assert Utilities.get_time_conversion_coeff(from_units="ns", to_units="ms") == 1e-6
+        assert Utilities.get_time_conversion_coeff(from_units="ns", to_units="micros") == 1e-3
+        assert Utilities.get_time_conversion_coeff(from_units="ns", to_units="ns") == 1
 
     def test_get_time_conversion_raise_error(self):
-        """Assert in utilities - ValueError is raised when wrong units given"""
-        self.assertRaises(ValueError, Utilities.get_time_conversion_coeff, "s", "bad_units")
-        self.assertRaises(ValueError, Utilities.get_time_conversion_coeff, "bad_units", "s")
-        self.assertRaises(ValueError, Utilities.get_time_conversion_coeff, "bad_units", "bad_units")
+        """ValueError is raised when wrong units given."""
+        with pytest.raises(ValueError):
+            Utilities.get_time_conversion_coeff("s", "bad_units")
+        with pytest.raises(ValueError):
+            Utilities.get_time_conversion_coeff("bad_units", "s")
+        with pytest.raises(ValueError):
+            Utilities.get_time_conversion_coeff("bad_units", "bad_units")
 
     def test_convert_time_units_single_value(self):
-        """Assert in utilities - converting single time units value"""
-        self.assertEqual(5, Utilities.convert_time_units(data=5, from_units="s", to_units="s"))
-        self.assertAlmostEqual(
-            4.5e-3, Utilities.convert_time_units(data=4500.0, from_units="micros", to_units="s"), delta=0.000000001
-        )
+        """Converting single time units value."""
+        assert Utilities.convert_time_units(data=5, from_units="s", to_units="s") == 5
+        result = Utilities.convert_time_units(data=4500.0, from_units="micros", to_units="s")
+        assert result == pytest.approx(4.5e-3, abs=0.000000001)
 
     def test_convert_time_units_list_array(self):
-        """Assert in utilities - converting list time units value"""
-        _data = [1, 2, 3, 4, 5]
-        self.assertTrue(all(_data == Utilities.convert_time_units(data=_data, from_units="s", to_units="s")))
+        """Converting list time units value."""
+        data = [1, 2, 3, 4, 5]
+        result = Utilities.convert_time_units(data=data, from_units="s", to_units="s")
+        assert all(data == result)
 
     def test_convert_time_units_numpy_array(self):
-        """Assert in utilities - converting numpy array time units value"""
-        _data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        self.assertTrue(all(_data == Utilities.convert_time_units(data=_data, from_units="s", to_units="s")))
+        """Converting numpy array time units value."""
+        data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = Utilities.convert_time_units(data=data, from_units="s", to_units="s")
+        assert all(data == result)
 
     def test_array_multiply_coeff_with_no_array(self):
-        """Assert in utilities - multiply nothing by a coeff value"""
-        self.assertRaises(ValueError, Utilities.array_multiply_coeff)
+        """Multiply nothing by a coeff value raises ValueError."""
+        with pytest.raises(ValueError):
+            Utilities.array_multiply_coeff()
 
     def test_array_multiply_coeff(self):
-        """Assert in utilities - multiply array by coeff value"""
-        _data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        _coeff = 2.5
-        _new_data = Utilities.array_multiply_coeff(data=_data, coeff=_coeff)
-        _expected_data = np.array([2.5, 5.0, 7.5, 10, 12.5])
-        self.assertTrue(all(_expected_data == _new_data))
+        """Multiply array by coeff value."""
+        data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        coeff = 2.5
+        new_data = Utilities.array_multiply_coeff(data=data, coeff=coeff)
+        expected_data = np.array([2.5, 5.0, 7.5, 10, 12.5])
+        assert all(expected_data == new_data)
 
     def test_array_add_coeff_with_no_array(self):
-        """Assert in utilities - add nothing to a coeff value"""
-        self.assertRaises(ValueError, Utilities.array_add_coeff)
+        """Add nothing to a coeff value raises ValueError."""
+        with pytest.raises(ValueError):
+            Utilities.array_add_coeff()
 
     def test_array_add_coeff(self):
-        """Assert in utilities - adding coeff to array"""
-        _data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        _coeff = 5.0
-        _new_data = Utilities.array_add_coeff(data=_data, coeff=_coeff)
-        _expected_data = np.array([6.0, 7.0, 8.0, 9.0, 10.0])
-        self.assertTrue(all(_expected_data == _new_data))
+        """Adding coeff to array."""
+        data = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        coeff = 5.0
+        new_data = Utilities.array_add_coeff(data=data, coeff=coeff)
+        expected_data = np.array([6.0, 7.0, 8.0, 9.0, 10.0])
+        assert all(expected_data == new_data)
 
     def test_array_divide_array_not_same_size(self):
-        """Assert in Utilities - Numerator array not same size as denominator array"""
-        _numerator = np.array([1, 2, 3])
-        _denominator = np.array([1, 2])
-        self.assertRaises(ValueError, Utilities.array_divide_array, _numerator, _denominator)
+        """Numerator array not same size as denominator array raises ValueError."""
+        numerator = np.array([1, 2, 3])
+        denominator = np.array([1, 2])
+        with pytest.raises(ValueError):
+            Utilities.array_divide_array(numerator, denominator)
 
     def test_array_divide_array_works(self):
-        """Assert in Utilities - Ratio of arrays works"""
-        _numerator = np.array([10, 20, 30, 40, 50])
-        _denominator = np.array([1, 2, 3, 4, 5])
-        _ratio_expected = np.array([10, 10, 10, 10, 10])
-        _ratio_returned = Utilities.array_divide_array(numerator=_numerator, denominator=_denominator)
-        self.assertTrue(all(_ratio_expected == _ratio_returned))
+        """Ratio of arrays works."""
+        numerator = np.array([10, 20, 30, 40, 50])
+        denominator = np.array([1, 2, 3, 4, 5])
+        ratio_expected = np.array([10, 10, 10, 10, 10])
+        ratio_returned = Utilities.array_divide_array(numerator=numerator, denominator=denominator)
+        assert all(ratio_expected == ratio_returned)
 
     def test_array_minus_array_raise_error(self):
-        """Assert in Utilities - array1 minus array2 raise error if not same size"""
-        _array1 = np.array([1, 2, 3])
-        _array2 = np.array([1, 2])
-        self.assertRaises(ValueError, Utilities.array_minus_array, _array1, _array2)
+        """Array1 minus array2 raises error if not same size."""
+        array1 = np.array([1, 2, 3])
+        array2 = np.array([1, 2])
+        with pytest.raises(ValueError):
+            Utilities.array_minus_array(array1, array2)
 
     def test_array_minus_array_works(self):
-        """Assert in Utilities - array1 minus array2 works returns correct array"""
-        _array1 = np.array([2, 4, 6])
-        _array2 = np.array([2, 3, 4])
-        _array_returned = Utilities.array_minus_array(_array1, _array2)
-        _array_expected = np.array([0, 1, 2])
-        self.assertTrue(all(_array_expected == _array_returned))
+        """Array1 minus array2 returns correct array."""
+        array1 = np.array([2, 4, 6])
+        array2 = np.array([2, 3, 4])
+        array_returned = Utilities.array_minus_array(array1, array2)
+        array_expected = np.array([0, 1, 2])
+        assert all(array_expected == array_returned)
 
-    def test_load_csv_raise_value_error(self):
-        """Assert in Utilities - testing load_csv - ValueError raised when wrong file format"""
-        input_file = self.get_full_path("bad_file.txt")
-        self.assertRaises(ValueError, Utilities.load_csv, input_file)
+    def test_load_csv_raise_value_error(self, get_data_file):
+        """ValueError raised when wrong file format."""
+        input_file = get_data_file("bad_file.txt")
+        with pytest.raises(ValueError):
+            Utilities.load_csv(input_file)
 
-    def test_load_ascii_raise_value_error(self):
-        """Assert in Utilities - testing load_ascii - ValueError is raised when file format is wrong"""
-        input_file = self.get_full_path("bad_file.txt")
-        self.assertRaises(ValueError, Utilities.load_ascii, input_file)
+    def test_load_ascii_raise_value_error(self, get_data_file):
+        """ValueError is raised when file format is wrong."""
+        input_file = get_data_file("bad_file.txt")
+        with pytest.raises(ValueError):
+            Utilities.load_ascii(input_file)
 
-    def test_load_ascii_with_space_separator(self):
-        """Assert in Utilities - testing load_ascii - space separated file read correctly"""
-        input_file = self.get_full_path("good_tof.txt")
-        _array = Utilities.load_ascii(filename=input_file, sep=" ")[0]
+    def test_load_ascii_with_space_separator(self, get_data_file):
+        """Space separated file read correctly."""
+        input_file = get_data_file("good_tof.txt")
+        array = Utilities.load_ascii(filename=input_file, sep=" ")[0]
         expected_start_of_array = np.array([[1.0, 20.0], [2.0, 21.0]])[0]
-        returned_array = _array[0:2]
-        self.assertTrue(all(expected_start_of_array == returned_array))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        returned_array = array[0:2]
+        assert all(expected_start_of_array == returned_array)


### PR DESCRIPTION
## Summary
- Converts all test files from unittest.TestCase style to native pytest
- Adds `tests/conftest.py` with shared fixtures (`data_path`, `get_data_file`)
- Replaces all unittest assertions with pytest equivalents (`assert`, `pytest.approx`, `pytest.raises`)
- Uses `tmp_path` fixture for temporary file tests
- **Fixes unit inconsistency bug in `test_experiment_calculate_main_coefficient`** (see #42)

## Changes
- 10 test files converted to native pytest style
- Removed `unittest.TestCase` inheritance
- Removed `unittest.main()` entry points
- Added shared fixtures for data file access
- Fixed `detector_offset_s = 4500e-6` → `detector_offset_micros = 4500` (was off by 1,000,000x)

## Bug Fix Details
The test `test_experiment_calculate_main_coefficient` had a unit inconsistency:
- Variable named `detector_offset_s` (suggesting seconds) with value `4500e-6` (0.0045)
- Passed to `detector_offset_micros` parameter which expects microseconds
- Code interpreted 0.0045 as microseconds → 4.5×10⁻⁹ seconds (instead of 0.0045 seconds)
- Bug was masked because the assertion didn't depend on this parameter

## Test plan
- [x] All 101 tests pass
- [x] Pre-commit checks pass
- [ ] CI pipeline passes

Closes #10
Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)