### PR TITLE
Set up GitHub Actions for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,68 +1,44 @@
-name: CI
+name: unit-test
 
 on:
-  push:
-    branches: [main, qa, next]
-    tags: ["v*"]
-  pull_request:
-    branches: [main, qa, next]
   workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  pull_request:
+  push:
+    branches:
+      - main
+      - qa
+      - next
+    tags:
+      - "v*"
 
 jobs:
-  test:
-    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12"]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Full history for versioningit
-
-      - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
-        with:
-          pixi-version: v0.39.5
-          cache: true
-          locked: false  # Allow lockfile updates for CI flexibility
-
-      - name: Run tests with coverage
-        run: pixi run test
-
-      - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          fail_ci_if_error: false
-          verbose: true
-
-  lint:
-    name: Lint
+  ubuntu-latest:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.3
         with:
-          pixi-version: v0.39.5
-          cache: true
-          locked: false  # Allow lockfile updates for CI flexibility
+          pixi-version: v0.62.0
+          manifest-path: pyproject.toml
+      - name: run unit tests
+        run: |
+          echo "running unit tests"
+          pixi run test
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ornlneutronimaging/BraggEdge
 
-      - name: Run linting
-        run: pixi run lint
-
-      - name: Check formatting
-        run: pixi run -e default ruff format --check src tests
+  macos-latest:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: prefix-dev/setup-pixi@v0.8.3
+        with:
+          pixi-version: v0.62.0
+          manifest-path: pyproject.toml
+      - name: run unit tests
+        run: |
+          echo "running unit tests"
+          pixi run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [main, qa, next]
+    tags: ["v*"]
+  pull_request:
+    branches: [main, qa, next]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for versioningit
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          cache: true
+
+      - name: Run tests with coverage
+        run: pixi run test
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false
+          verbose: true
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          cache: true
+
+      - name: Run linting
+        run: pixi run lint
+
+      - name: Check formatting
+        run: pixi run -e default ruff format --check src tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           pixi-version: v0.39.5
           cache: true
+          locked: false  # Allow lockfile updates for CI flexibility
 
       - name: Run tests with coverage
         run: pixi run test
@@ -58,6 +59,7 @@ jobs:
         with:
           pixi-version: v0.39.5
           cache: true
+          locked: false  # Allow lockfile updates for CI flexibility
 
       - name: Run linting
         run: pixi run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           pixi-version: v0.39.5
           cache: true
+          locked: false  # Allow lockfile updates for build flexibility
 
       - name: Build package
         run: pixi run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,94 @@
+name: Publish
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (skip actual publishing)"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for versioningit
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          cache: true
+
+      - name: Build package
+        run: pixi run build
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && !inputs.dry_run
+    environment:
+      name: pypi
+      url: https://pypi.org/project/neutronbraggedge/
+    permissions:
+      id-token: write  # Required for trusted publishing
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && !inputs.dry_run
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Determine release type
+        id: release-type
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          if [[ "$TAG" == *"rc"* ]] || [[ "$TAG" == *"alpha"* ]] || [[ "$TAG" == *"beta"* ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          prerelease: ${{ steps.release-type.outputs.prerelease }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,95 +1,76 @@
-name: Publish
+name: packaging and publish
 
 on:
-  push:
-    tags: ["v*"]
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: "Dry run (skip actual publishing)"
-        required: false
-        default: false
-        type: boolean
+  pull_request:
+  push:
+    branches:
+      - main
+      - qa
+      - next
+    tags:
+      - "v*"
+
+# cancel previous job if new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build distribution
+  linux:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Full history for versioningit
-
-      - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
-        with:
-          pixi-version: v0.39.5
-          cache: true
-          locked: false  # Allow lockfile updates for build flexibility
-
-      - name: Build package
-        run: pixi run build
-
-      - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-          if-no-files-found: error
-
-  publish-pypi:
-    name: Publish to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && !inputs.dry_run
-    environment:
-      name: pypi
-      url: https://pypi.org/project/neutronbraggedge/
-    permissions:
-      id-token: write  # Required for trusted publishing
-
-    steps:
-      - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-  github-release:
-    name: Create GitHub Release
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v') && !inputs.dry_run
     permissions:
       contents: write
-
+      id-token: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history for versioningit
+      - uses: prefix-dev/setup-pixi@v0.8.3
+        with:
+          pixi-version: v0.62.0
+          manifest-path: pyproject.toml
+      - name: build PyPI package
+        run: |
+          echo "Build PyPI package"
+          pixi run build
+      - name: upload PyPI artifact
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/upload-artifact@v4
+        with:
+          name: pypi-package
+          path: dist/*
+      - name: publish PyPI package
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@release/v1
 
-      - name: Download distribution artifacts
+  # Create GitHub Release with auto-generated release notes
+  github-release:
+    name: Create GitHub Release
+    needs: linux
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download PyPI artifact
         uses: actions/download-artifact@v4
         with:
-          name: dist
-          path: dist/
+          name: pypi-package
+          path: dist/pypi
 
-      - name: Determine release type
-        id: release-type
+      - name: List artifacts
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
-          if [[ "$TAG" == *"rc"* ]] || [[ "$TAG" == *"alpha"* ]] || [[ "$TAG" == *"beta"* ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-          fi
+          echo "PyPI packages:"
+          ls -la dist/pypi/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*
+          files: |
+            dist/pypi/*
           generate_release_notes: true
-          prerelease: ${{ steps.release-type.outputs.prerelease }}
+          draft: false
+          prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -1,0 +1,54 @@
+name: Update Lockfiles
+
+on:
+  schedule:
+    # Run monthly on the first day at 00:00 UTC
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-lockfiles:
+    name: Update pixi.lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.5
+          cache: false  # Don't cache when updating
+
+      - name: Update lockfile
+        run: pixi update
+
+      - name: Check for changes
+        id: check-changes
+        run: |
+          if git diff --quiet pixi.lock; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update pixi.lock"
+          title: "chore: Update dependency lockfile"
+          body: |
+            This PR updates `pixi.lock` with the latest compatible dependency versions.
+
+            **Automated PR** - Created by the monthly lockfile update workflow.
+
+            Please review the changes and ensure tests pass before merging.
+          branch: chore/update-lockfiles
+          delete-branch: true
+          labels: dependencies

--- a/.github/workflows/update-lockfiles.yml
+++ b/.github/workflows/update-lockfiles.yml
@@ -1,54 +1,37 @@
-name: Update Lockfiles
-
-on:
-  schedule:
-    # Run monthly on the first day at 00:00 UTC
-    - cron: "0 0 1 * *"
-  workflow_dispatch:
+name: Update lockfiles
 
 permissions:
   contents: write
   pull-requests: write
 
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 5 1 * *
+
 jobs:
-  update-lockfiles:
-    name: Update pixi.lock
+  pixi-update:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+      - uses: actions/checkout@v4
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.3
         with:
-          pixi-version: v0.39.5
-          cache: false  # Don't cache when updating
-
-      - name: Update lockfile
-        run: pixi update
-
-      - name: Check for changes
-        id: check-changes
+          pixi-version: v0.62.0
+          run-install: false
+      - name: Update lockfiles
         run: |
-          if git diff --quiet pixi.lock; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
-            echo "changed=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Create Pull Request
-        if: steps.check-changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v6
+          set -o pipefail
+          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update pixi.lock"
-          title: "chore: Update dependency lockfile"
-          body: |
-            This PR updates `pixi.lock` with the latest compatible dependency versions.
-
-            **Automated PR** - Created by the monthly lockfile update workflow.
-
-            Please review the changes and ensure tests pass before merging.
-          branch: chore/update-lockfiles
+          commit-message: Update pixi lockfile
+          title: Update pixi lockfile
+          body-path: diff.md
+          branch: update-pixi
+          base: next
+          labels: pixi
           delete-branch: true
-          labels: dependencies
+          add-paths: pixi.lock

--- a/pixi.lock
+++ b/pixi.lock
@@ -1958,7 +1958,7 @@ packages:
   timestamp: 1738196177597
 - pypi: ./
   name: neutronbraggedge
-  version: 2.1.0.dev2+d202601280049
+  version: 2.1.0.dev4+d202601280127
   sha256: e8fb3474648db2b5fcad622161b12a3e3784649190d7e626b5313e96a48606bd
   requires_dist:
   - numpy>=1.24


### PR DESCRIPTION
## Summary
Replace Travis CI with GitHub Actions for modern CI/CD. Based on patterns from iBeatles repository.

### Workflows Added

#### 1. Unit Test (`ci.yml`)
- **Triggers**: Push to main/qa/next, PRs, tags, manual dispatch
- **Jobs**: Separate ubuntu-latest and macos-latest jobs
- **Stack**: Pixi v0.62.0, setup-pixi v0.8.3
- **Coverage**: Uploads to Codecov (ubuntu only)

#### 2. Packaging and Publish (`publish.yml`)
- **Triggers**: Push to main/qa/next, PRs, tags, manual dispatch
- **Build**: PyPI wheel/sdist via `pixi run build`
- **Publish**: PyPI trusted publishing on version tags
- **Release**: Auto-generated GitHub Release with artifacts

#### 3. Update Lockfiles (`update-lockfiles.yml`)
- **Triggers**: Monthly schedule (1st of month), manual dispatch
- **Action**: Updates pixi.lock and creates PR with diff markdown
- **Target**: next branch

## Setup Required
After merging:
1. **Codecov**: Add `CODECOV_TOKEN` secret
2. **PyPI**: Enable trusted publishing at pypi.org for this repository
3. **.travis.yml**: Can be removed in follow-up PR (#20)

## Test plan
- [x] YAML syntax validated
- [x] Pre-commit checks pass
- [x] CI workflow passes (ubuntu + macos)
- [x] Publish workflow builds successfully

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)