### PR TITLE
Fix code quality issues #29-33

### DIFF
--- a/src/neutronbraggedge/braggedge.py
+++ b/src/neutronbraggedge/braggedge.py
@@ -112,9 +112,19 @@ class BraggEdge:
     def get_experimental_lattice_parameter(
         self, experimental_bragg_edge_values=None, experimental_bragg_edge_error=None
     ):
-        """calculates the experimental lattice parameter values given an array of
-        bragg edge values"""
+        """Calculates the experimental lattice parameter values given an array of
+        bragg edge values.
 
+        Note: This method is not yet implemented. Use the Lattice class directly
+        for experimental lattice parameter calculations.
+
+        Args:
+            experimental_bragg_edge_values: Array of experimental bragg edge values
+            experimental_bragg_edge_error: Optional array of errors
+
+        Raises:
+            NotImplementedError: This method is not yet implemented
+        """
         if experimental_bragg_edge_values is None:
             raise ValueError("Please provide an array of bragg edge values")
 
@@ -122,10 +132,10 @@ class BraggEdge:
             if len(experimental_bragg_edge_error) != len(experimental_bragg_edge_values):
                 raise ValueError("Make sure exp. bragg edge value and error have the same size!")
 
-        _calculator = self._calculator
-        _calculator.calculate_lattice_array(experimental_bragg_edge_values, experimental_bragg_edge_error)
-        exp_lattice_parameter = _calculator.lattice_experimentatl
-        return exp_lattice_parameter
+        raise NotImplementedError(
+            "get_experimental_lattice_parameter is not yet implemented. "
+            "Use the Lattice class directly for experimental lattice calculations."
+        )
 
     def _retrieve_metadata(self, new_material=None):
         """This method retrieves the lattice and crystal structure of the material"""

--- a/src/neutronbraggedge/braggedge.py
+++ b/src/neutronbraggedge/braggedge.py
@@ -119,11 +119,16 @@ class BraggEdge:
         for experimental lattice parameter calculations.
 
         Args:
-            experimental_bragg_edge_values: Array of experimental bragg edge values
-            experimental_bragg_edge_error: Optional array of errors
+            experimental_bragg_edge_values: Array of experimental bragg edge values.
+            experimental_bragg_edge_error: Optional array of errors corresponding to
+                ``experimental_bragg_edge_values``.
 
         Raises:
-            NotImplementedError: This method is not yet implemented
+            ValueError: If ``experimental_bragg_edge_values`` is not provided, or if
+                ``experimental_bragg_edge_error`` is provided and its length does not
+                match ``experimental_bragg_edge_values``.
+            NotImplementedError: This method is not yet implemented. Use the Lattice
+                class directly for experimental lattice parameter calculations.
         """
         if experimental_bragg_edge_values is None:
             raise ValueError("Please provide an array of bragg edge values")

--- a/src/neutronbraggedge/braggedges_handler/braggedge_calculator.py
+++ b/src/neutronbraggedge/braggedges_handler/braggedge_calculator.py
@@ -35,7 +35,7 @@ class BraggEdgeCalculator:
         self._list_structure = ast.literal_eval(config_obj["DEFAULT"]["list_structure"])
 
         if structure_name not in self._list_structure:
-            raise ValueError("Structure name should be in the list ", self._list_structure)
+            raise ValueError(f"Structure name should be in the list {self._list_structure}")
         self._structure = structure_name
 
     def calculate_hkl(self):

--- a/src/neutronbraggedge/braggedges_handler/braggedge_calculator.py
+++ b/src/neutronbraggedge/braggedges_handler/braggedge_calculator.py
@@ -1,3 +1,4 @@
+import ast
 import configparser
 
 import numpy as np
@@ -29,11 +30,9 @@ class BraggEdgeCalculator:
     @structure.setter
     def structure(self, structure_name):
         _config_file = config_config_file
-        # print("config file ({}) exists? {}".format(_config_file, os.path.exists(_config_file)))
-        # _config_file = os.path.abspath('../config.cfg')
         config_obj = configparser.ConfigParser()
         config_obj.read(_config_file)
-        self._list_structure = config_obj["DEFAULT"]["list_structure"]
+        self._list_structure = ast.literal_eval(config_obj["DEFAULT"]["list_structure"])
 
         if structure_name not in self._list_structure:
             raise ValueError("Structure name should be in the list ", self._list_structure)
@@ -60,47 +59,3 @@ class BraggEdgeCalculator:
     def _calculate_individual_bragg_edge(self, lattice=None, h=1, k=1, l=1):
         _den = np.sqrt(h**2 + k**2 + l**2)
         return float(lattice) / _den
-
-    # def _calculate_individual_lattice(self, h=1, k=1, l=1, bragg_edge_value=0, bragg_edge_error=0):
-    # _num = np.sqrt(h**2 + k**2 + l**2)
-    # _value = float(bragg_edge_value/2.)*_num
-    # _error = float(bragg_edge_error/2.)*_num
-    # return [_value, _error]
-
-    # def calculate_lattice_array(self, exp_bragg_edge_value, exp_bragg_edge_error=None):
-    # """calculate the lattice given the hkl and bragg edge value"""
-    # _lattice_array = []
-    # _lattice_error_array = []
-    # for _index, _hkl in enumerate(exp_bragg_edge_value):
-    # _hkl = self.hkl[_index]
-    # _bragg = exp_bragg_edge_value[_index]
-
-    # if exp_bragg_edge_error is not None:
-    # _error = exp_bragg_edge_error[_index]
-    # else:
-    # _error = 0
-    # [_result, _result_error] = self._calculate_individual_lattice(h = _hkl[0],
-    # k = _hkl[1],
-    # l = _hkl[2],
-    # bragg_edge_value = _bragg,
-    # bragg_edge_error = _error)
-    # _lattice_array.append(_result)
-    # _lattice_error_array.append(_result_error)
-
-    # self.lattice_experimental = _lattice_array
-    # self.lattice_error_experimental = _lattice_error_array
-
-    # self.average_lattice_experimental = self._calculate_average_lattice_experimental()
-
-    # def _calculate_average_lattice_experimental(self):
-    # _lattice_exp = self.lattice_experimental
-    # _lattice_error_exp = self.lattice_error_experimental
-
-    # _mean_value = np.mean(_lattice_exp)
-    # _sum_error = 0
-    # for _error in _lattice_error_exp:
-    # _sum_error += _error * _error
-
-    # _mean_error = np.sqrt(_sum_error)
-
-    # self.mean_lattice_experimental = [_mean_value, _mean_error]

--- a/src/neutronbraggedge/lattice_handler/lattice.py
+++ b/src/neutronbraggedge/lattice_handler/lattice.py
@@ -1,3 +1,4 @@
+import ast
 import configparser
 
 import numpy as np
@@ -50,7 +51,7 @@ class Lattice:
         _config_file = config_config_file
         config_obj = configparser.ConfigParser()
         config_obj.read(_config_file)
-        self._list_structure = config_obj["DEFAULT"]["list_structure"]
+        self._list_structure = ast.literal_eval(config_obj["DEFAULT"]["list_structure"])
 
         if structure_name not in self._list_structure:
             raise ValueError("Structure name should be in the list ", self._list_structure)

--- a/src/neutronbraggedge/lattice_handler/lattice.py
+++ b/src/neutronbraggedge/lattice_handler/lattice.py
@@ -54,7 +54,7 @@ class Lattice:
         self._list_structure = ast.literal_eval(config_obj["DEFAULT"]["list_structure"])
 
         if structure_name not in self._list_structure:
-            raise ValueError("Structure name should be in the list ", self._list_structure)
+            raise ValueError(f"Structure name should be in the list {self._list_structure}")
         self._crystal_structure = structure_name
 
     def _format_array(self, bragg_edge_array):

--- a/src/neutronbraggedge/utilities.py
+++ b/src/neutronbraggedge/utilities.py
@@ -188,8 +188,10 @@ class Utilities:
                     _value = float(_line.strip())
                     _tof.append(_value)
                 return _tof
-        except:
-            raise ValueError("Bad file format")
+        except OSError:
+            raise
+        except ValueError as e:
+            raise ValueError("Bad file format") from e
 
     @staticmethod
     def load_ascii(filename=None, sep=""):

--- a/src/neutronbraggedge/utilities.py
+++ b/src/neutronbraggedge/utilities.py
@@ -180,14 +180,14 @@ class Utilities:
         """
         _input_file = filename
         try:
-            f = open(_input_file)
-            _tof = []
-            for _line in f:
-                if "#" in _line:
-                    continue
-                _value = float(_line.strip())
-                _tof.append(_value)
-            return _tof
+            with open(_input_file) as f:
+                _tof = []
+                for _line in f:
+                    if "#" in _line:
+                        continue
+                    _value = float(_line.strip())
+                    _tof.append(_value)
+                return _tof
         except:
             raise ValueError("Bad file format")
 
@@ -221,14 +221,13 @@ class Utilities:
         * metadata: metadata string array (will be placed at the top of the file with '#' in front)
         * data: data float array"""
         sep = ", "
-        f = open(filename, "w")
-        for _meta in metadata:
-            f.write("# " + _meta + "\n")
-        for _row in data:
-            if (type(_row) is np.ndarray) or (type(_row) is list):
-                _row_string = [str(x) for x in _row]
-                _row_format = sep.join(_row_string)
-            else:
-                _row_format = str(_row)
-            f.write(_row_format + "\n")
-        f.close()
+        with open(filename, "w") as f:
+            for _meta in metadata:
+                f.write("# " + _meta + "\n")
+            for _row in data:
+                if (type(_row) is np.ndarray) or (type(_row) is list):
+                    _row_string = [str(x) for x in _row]
+                    _row_format = sep.join(_row_string)
+                else:
+                    _row_format = str(_row)
+                f.write(_row_format + "\n")

--- a/tests/data/bad_file.txt
+++ b/tests/data/bad_file.txt
@@ -1,0 +1,2 @@
+not_a_number
+this is invalid data

--- a/tests/neutronbraggedge/braggedge_handler/braggedge_calculator_test.py
+++ b/tests/neutronbraggedge/braggedge_handler/braggedge_calculator_test.py
@@ -19,6 +19,16 @@ class TestBraggEdgeCalculator:
         with pytest.raises(ValueError):
             BraggEdgeCalculator(structure_name)
 
+    def test_braggedge_calculator_error_when_substring_structure_given(self):
+        """Error is raised when structure name is a substring of valid names.
+
+        This tests the fix for the substring membership bug where "CC" would
+        incorrectly be accepted because it's a substring of "FCC" and "BCC".
+        """
+        structure_name = "CC"
+        with pytest.raises(ValueError):
+            BraggEdgeCalculator(structure_name)
+
     def test_right_structure_name_is_passed_in_constructor(self):
         """Structure name passed in constructor is correctly used."""
         structure_name = "BCC"

--- a/tests/neutronbraggedge/braggedge_test.py
+++ b/tests/neutronbraggedge/braggedge_test.py
@@ -155,6 +155,18 @@ class TestBraggEdge:
         with pytest.raises(ValueError):
             handler.get_experimental_lattice_parameter(exp_bragg_value, exp_bragg_error)
 
+    def test_calculate_experimental_lattice_raises_not_implemented_error(self):
+        """NotImplementedError raised when calling get_experimental_lattice_parameter with valid inputs.
+
+        This method is not yet implemented and should raise NotImplementedError
+        directing users to use the Lattice class directly.
+        """
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        exp_bragg_value = np.array([4.0537, 2.8664, 2.3404, 2.0269])
+        exp_bragg_error = np.array([0.001, 0.001, 0.001, 0.001])
+        with pytest.raises(NotImplementedError):
+            handler.get_experimental_lattice_parameter(exp_bragg_value, exp_bragg_error)
+
     def test_loading_single_material_in_list(self):
         """Single element Al data listed in a list correctly calculated."""
         # Just verify no exception is raised

--- a/tests/neutronbraggedge/utilities_test.py
+++ b/tests/neutronbraggedge/utilities_test.py
@@ -134,6 +134,11 @@ class TestUtilities:
         with pytest.raises(ValueError):
             Utilities.load_csv(input_file)
 
+    def test_load_csv_raise_file_not_found_error(self):
+        """FileNotFoundError raised when file does not exist."""
+        with pytest.raises(FileNotFoundError):
+            Utilities.load_csv("/nonexistent/path/to/file.txt")
+
     def test_load_ascii_raise_value_error(self, get_data_file):
         """ValueError is raised when file format is wrong."""
         input_file = get_data_file("bad_file.txt")


### PR DESCRIPTION
## Summary
Fix code quality issues identified during Copilot review of PR #24.

## Issues Fixed

### #29 - String membership check on config list is fragile
**Problem:** `list_structure` from config.cfg was a string like `"['FCC', 'BCC']"`. Using `in` operator did substring matching, so `"CC"` would incorrectly match.

**Fix:** Use `ast.literal_eval()` to parse the string into an actual list for proper membership checking.

**Files:** `braggedge_calculator.py`, `lattice.py`

### #31 - File handles not properly closed in utilities.py
**Problem:** `load_csv` and `save_csv` opened files without context managers, risking resource leaks on exceptions.

**Fix:** Use `with open(...) as f:` context managers.

**File:** `utilities.py`

### #32 - Remove commented-out dead code
**Problem:** ~40 lines of commented-out experimental lattice calculation code in `braggedge_calculator.py`.

**Fix:** Removed. Code is preserved in git history if needed.

**File:** `braggedge_calculator.py`

### #33 - Broken experimental lattice code path
**Problem:** `get_experimental_lattice_parameter` called commented-out method and had typo (`lattice_experimentatl`).

**Fix:** Changed to raise `NotImplementedError` with helpful message pointing to `Lattice` class.

**File:** `braggedge.py`

### #30 - Unused variables (Not Changed)
The variables `_lattice_constant` and `_crystal_structure` in `braggedge.py:94-95` appear unused but actually serve to validate the dictionary format - if the keys don't exist, an exception is raised. This is intentional validation logic.

## Test plan
- [x] All 101 tests pass
- [x] Pre-commit checks pass
- [ ] CI passes

Closes #29, #31, #32, #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)