### PR TITLE
Add Dependabot and GitHub Release notes configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Update GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    target-branch: "next"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Update pip dependencies (pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    target-branch: "next"
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - "skip-changelog"
+  categories:
+    - title: "Breaking Changes"
+      labels:
+        - "breaking-change"
+    - title: "New Features"
+      labels:
+        - "enhancement"
+        - "feature"
+    - title: "Bug Fixes"
+      labels:
+        - "bug"
+        - "fix"
+    - title: "Documentation"
+      labels:
+        - "documentation"
+    - title: "Infrastructure"
+      labels:
+        - "infrastructure"
+        - "ci-cd"
+        - "modernization"
+    - title: "Dependencies"
+      labels:
+        - "dependencies"
+    - title: "Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary
- Configure Dependabot for automated dependency updates
- Add release notes template for auto-generated changelogs

## Changes

### Dependabot (`.github/dependabot.yml`)
- **GitHub Actions**: Weekly updates with grouping (all actions in single PR)
- **pip dependencies**: Monthly updates with grouping (minor/patch in single PR)
- All PRs target the `next` branch
- Uses `groups` feature to reduce PR noise ([docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups))

### Release Notes (`.github/release.yml`)
- Categorizes PRs by labels for auto-generated release notes
- Categories: Breaking Changes, Features, Bug Fixes, Documentation, Infrastructure, Dependencies

## Triggering Dependabot
After merge, Dependabot will start automatically. To trigger immediately:
1. Go to **Insights** → **Dependency graph** → **Dependabot**
2. Click **Check for updates** next to each ecosystem

Or run manually: `gh api -X POST /repos/ornlneutronimaging/BraggEdge/dependabot/refresh`

## Test plan
- [x] YAML syntax validated by pre-commit hooks
- [ ] Verify Dependabot creates PRs after merge
- [ ] Verify release notes are generated correctly on next tag

Closes #14, closes #15

Sources:
- [Dependabot options reference](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)
- [Dependabot groups](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)