### PR TITLE
Fix documentation examples with incorrect parameter names

### DIFF
--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -152,11 +152,11 @@ In order to convert a TOF range into lambda, you will need to provide:
 
 First, you need to load your TOF range. You can either provide this array
 
->>> _tof_handler = TOF(tof = [9.6000E-07, 1.1200E-05, 2.1440E-05, 3.1680E-05], units = 'micros')
+>>> _tof_handler = TOF(tof_array=[9.6000E-07, 1.1200E-05, 2.1440E-05, 3.1680E-05], units='micros')
 
 or by providing the name of an ascii file name where each tof is on its own row
 
->>> _tof_handler = TOF(filename = my_tof.txt, units = 'micros')
+>>> _tof_handler = TOF(filename='my_tof.txt', units='micros')
 
 Then it is possible to calculate the Lambda array
 
@@ -183,11 +183,11 @@ In order to calculate the *source-detector* length, you must provide:
 
 First, you need to load your TOF range. You can either provide this array
 
->>> _tof_handler = TOF(tof = [9.6000E-07, 1.1200E-05, 2.1440E-05, 3.1680E-05], units = 'micros')
+>>> _tof_handler = TOF(tof_array=[9.6000E-07, 1.1200E-05, 2.1440E-05, 3.1680E-05], units='micros')
 
 or by providing the name of an ascii file name where each tof is on its own row
 
->>> _tof_handler = TOF(filename = my_tof.txt, units = 'micros')
+>>> _tof_handler = TOF(filename='my_tof.txt', units='micros')
 
 Same thing with lambda array
 
@@ -217,11 +217,11 @@ In order to calculate the *detector offsetr*, you must provide:
 
 First, you need to load your TOF range. You can either provide this array
 
->>> _tof_handler = TOF(tof = [9.6000E-07, 1.1200E-05, 2.1440E-05, 3.1680E-05], units = 'micros')
+>>> _tof_handler = TOF(tof_array=[9.6000E-07, 1.1200E-05, 2.1440E-05, 3.1680E-05], units='micros')
 
 or by providing the name of an ascii file name where each tof is on its own row
 
->>> _tof_handler = TOF(filename = my_tof.txt, units = 'micros')
+>>> _tof_handler = TOF(filename='my_tof.txt', units='micros')
 
 Same thing with lambda array
 

--- a/src/neutronbraggedge/material_handler/retrieve_metadata_table.py
+++ b/src/neutronbraggedge/material_handler/retrieve_metadata_table.py
@@ -25,12 +25,12 @@ class RetrieveMetadataTable:
     web page: `Lattice constant
     <https://en.wikipedia.org/wiki/Lattice_constant>`.
 
-    >>> from braggedge.material_hanlder.retrieve_metadata_table import RetrieveMetadataTable
+    >>> from neutronbraggedge.material_handler.retrieve_metadata_table import RetrieveMetadataTable
     >>> retrieve_local_meta = RetrieveMetadataTable()
     >>> _table = retrieve_local_meta.get_table()
 
-    >>> retrieve_url_meta = RetrieveMetadataTable()
-    >>> _table = retrieve_url_meta.get_table(use_local_table = False)
+    >>> retrieve_url_meta = RetrieveMetadataTable(use_local_table=False)
+    >>> _table = retrieve_url_meta.get_table()
 
     """
 


### PR DESCRIPTION
## Summary
Fix incorrect parameter names in documentation examples found during Copilot review of PR #24.

## Changes

### `retrieve_metadata_table.py` (#34)
- **Before**: `get_table(use_local_table=False)` - incorrect, method takes no parameters
- **After**: `RetrieveMetadataTable(use_local_table=False)` then `get_table()`
- Also fixed import path typo: `braggedge.material_hanlder` → `neutronbraggedge.material_handler`

### `docs/demo.rst` (#35)
- **Before**: `TOF(tof=[...], units='micros')` - incorrect parameter name
- **After**: `TOF(tof_array=[...], units='micros')` - matches actual `__init__` signature
- Fixed all 3 occurrences in Lambda, Distance, and Offset calculation sections
- Added quotes around filename strings in examples

## Test plan
- [x] All 104 tests pass
- [x] Pre-commit hooks pass

Closes #34, closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)