### PR TITLE
Add contributor documentation and AI assistant instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,7 +18,7 @@ Key concepts:
 
 ## Technology Stack
 
-- **Python**: 3.11-3.12
+- **Python**: 3.11+
 - **Core dependencies**: numpy, pandas, lxml, beautifulsoup4
 - **Environment management**: Pixi (conda-based)
 - **Testing**: pytest with pytest-cov

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,156 @@
+# BraggEdge AI Assistant Instructions
+
+This document provides context for AI assistants (Claude Code, GitHub Copilot, etc.) working on this codebase.
+
+## Project Overview
+
+**neutronbraggedge** is a scientific Python library for neutron Bragg edge analysis used in neutron imaging research at Oak Ridge National Laboratory (ORNL).
+
+### What are Bragg Edges?
+
+Bragg edges occur at specific wavelengths in neutron transmission spectra due to crystallographic diffraction. When the neutron wavelength satisfies `λ = 2d`, where `d` is the crystal lattice spacing, neutrons are diffracted out of the beam, causing a sharp "edge" in the transmission spectrum.
+
+Key concepts:
+- **d-spacing**: Distance between crystal planes, calculated from Miller indices (h,k,l) and lattice parameter
+- **Bragg edge wavelength**: `λ = 2d` (twice the d-spacing)
+- **Crystal structures**: FCC (face-centered cubic), BCC (body-centered cubic)
+- **Miller indices**: (h,k,l) notation for crystal planes - these are standard crystallography notation, not ambiguous variable names
+
+## Technology Stack
+
+- **Python**: 3.11-3.12
+- **Core dependencies**: numpy, pandas, lxml, beautifulsoup4
+- **Environment management**: Pixi (conda-based)
+- **Testing**: pytest with pytest-cov
+- **Linting/Formatting**: Ruff
+- **CI/CD**: GitHub Actions
+- **Versioning**: versioningit (git tag-based)
+
+## Project Structure
+
+```
+src/neutronbraggedge/
+├── braggedge.py              # Main BraggEdge class (user entry point)
+├── braggedges_handler/       # Bragg edge calculations
+│   ├── braggedge_calculator.py
+│   └── structure_handler.py  # FCC/BCC structure handling
+├── experiment_handler/       # Experimental data handling
+│   ├── experiment.py         # Main experiment class
+│   ├── tof.py               # Time-of-flight handling
+│   └── lambda_wavelength.py  # Wavelength calculations
+├── lattice_handler/          # Lattice parameter calculations
+│   └── lattice.py
+├── material_handler/         # Material metadata
+│   ├── retrieve_material_metadata.py
+│   └── retrieve_metadata_table.py
+├── data/                     # Static data files (material tables)
+├── config.py                 # Configuration paths
+└── utilities.py              # Shared utilities
+```
+
+## Code Style
+
+### Formatting (enforced by Ruff)
+- Line length: 120 characters
+- Quote style: double quotes
+- Indent style: spaces (4)
+- Import sorting: isort-compatible
+
+### Conventions
+- Use `snake_case` for functions and variables
+- Use `PascalCase` for classes
+- Prefix private methods with `_`
+- Miller indices variables (h, k, l) are intentionally single letters - this is standard crystallography notation
+
+### Ruff Rules
+```toml
+select = ["E", "F", "I", "W", "UP"]
+ignore = ["E741"]  # Allow h,k,l variable names (Miller indices)
+```
+
+## Testing
+
+### Running Tests
+```bash
+pixi run test        # Full test suite with coverage
+pixi run test-fast   # Quick test run (stop on first failure)
+```
+
+### Test Conventions
+- Test files: `*_test.py` pattern
+- Test data: `tests/data/` directory
+- Use pytest fixtures from `tests/conftest.py`
+- Aim for 80%+ coverage (currently ~95%)
+- Use `pytest.approx()` for floating-point comparisons
+
+### Example Test Pattern
+```python
+class TestClassName:
+    def test_specific_behavior(self):
+        """Docstring describing what is being tested."""
+        handler = SomeClass(param=value)
+        result = handler.method()
+        assert result == expected
+```
+
+## Development Workflow
+
+### Branch Structure
+- `next`: Development branch (default, PRs target here)
+- `qa`: Quality assurance (pre-release testing)
+- `main`: Stable releases only
+
+### Common Tasks
+```bash
+pixi run test          # Run tests
+pixi run lint          # Check code style
+pixi run format        # Auto-format code
+pixi run pre-commit    # Run all pre-commit hooks
+pixi run build         # Build package
+```
+
+## Domain-Specific Knowledge
+
+### Key Classes
+
+1. **BraggEdge**: Main entry point for users
+   - Input: material name(s), number of Bragg edges
+   - Output: hkl values, d-spacing, Bragg edge wavelengths
+
+2. **Lattice**: Calculate lattice parameters from experimental data
+   - Input: crystal structure, experimental Bragg edge array
+   - Output: lattice parameter statistics
+
+3. **TOF**: Time-of-flight data handling
+   - Constructor param is `tof_array`, not `tof`
+   - Supports unit conversion (s, ms, micros, ns)
+
+4. **Experiment**: Calculate wavelength from TOF
+   - Requires: distance_source_detector_m, detector_offset_micros
+
+### Common Materials
+- Fe (iron): BCC, lattice 2.8664 Å
+- Ni (nickel): FCC, lattice 3.5238 Å
+- Al (aluminum): FCC, lattice 4.0460 Å
+- Cu (copper): FCC, lattice 3.6149 Å
+
+### Physical Constants
+- Neutron mass: defined in `constants.py`
+- Planck constant: defined in `constants.py`
+
+## Common Pitfalls to Avoid
+
+1. **Parameter names**: `TOF` uses `tof_array`, not `tof`
+2. **Constructor vs method params**: Some flags like `use_local_table` are constructor parameters, not method parameters
+3. **Import paths**: Use `neutronbraggedge`, not `braggedge`
+4. **Crystal structures**: Only "FCC" and "BCC" are currently supported
+5. **Units**: Be explicit about units (seconds, microseconds, Angstroms)
+
+## When Making Changes
+
+1. Read the file before editing
+2. Run `pixi run test` after changes
+3. Run `pixi run pre-commit` before committing
+4. Follow existing patterns in the codebase
+5. Don't add features beyond what's requested
+6. Keep changes minimal and focused

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,187 @@
+# Contributing to BraggEdge
+
+Thank you for your interest in contributing to neutronbraggedge! This document provides guidelines for contributing to the project.
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11 or 3.12
+- [Pixi](https://pixi.sh/) for environment management
+
+### Setting Up the Development Environment
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/ornlneutronimaging/BraggEdge.git
+   cd BraggEdge
+   ```
+
+2. Install dependencies with Pixi:
+   ```bash
+   pixi install
+   ```
+
+3. Install pre-commit hooks:
+   ```bash
+   pixi run pre-commit-install
+   ```
+
+4. Verify your setup:
+   ```bash
+   pixi run test
+   ```
+
+## Development Workflow
+
+### Branch Structure
+
+We use a three-branch workflow:
+
+- **`next`**: Development branch (default). All PRs should target this branch.
+- **`qa`**: Quality assurance branch for pre-release testing.
+- **`main`**: Stable release branch. Only receives merges from `qa`.
+
+### Making Changes
+
+1. Create a feature branch from `next`:
+   ```bash
+   git checkout next
+   git pull origin next
+   git checkout -b feature/your-feature-name
+   ```
+
+2. Make your changes and commit:
+   ```bash
+   git add <files>
+   git commit -m "Brief description of changes"
+   ```
+
+3. Push and create a pull request:
+   ```bash
+   git push -u origin feature/your-feature-name
+   ```
+
+4. Open a PR targeting the `next` branch.
+
+## Code Style
+
+We use [Ruff](https://github.com/astral-sh/ruff) for linting and formatting.
+
+### Key Style Points
+
+- **Line length**: 120 characters
+- **Quotes**: Double quotes
+- **Imports**: Sorted with isort-compatible ordering
+
+### Running Linters
+
+```bash
+pixi run lint      # Check for issues
+pixi run format    # Auto-format code
+```
+
+### Pre-commit Hooks
+
+Pre-commit hooks run automatically on commit. To run manually:
+
+```bash
+pixi run pre-commit
+```
+
+## Testing
+
+### Running Tests
+
+```bash
+pixi run test        # Full suite with coverage
+pixi run test-fast   # Quick run (stops on first failure)
+```
+
+### Writing Tests
+
+- Place tests in `tests/` mirroring the source structure
+- Use `*_test.py` naming pattern
+- Use pytest fixtures for common setup
+- Use `pytest.approx()` for floating-point comparisons
+
+Example:
+```python
+import pytest
+from neutronbraggedge.braggedge import BraggEdge
+
+class TestBraggEdge:
+    def test_calculates_d_spacing_correctly(self):
+        """d_spacing values should match expected crystallographic values."""
+        handler = BraggEdge(material="Fe", number_of_bragg_edges=4)
+        d_spacing = handler.d_spacing["Fe"]
+        assert d_spacing[0] == pytest.approx(2.0269, abs=0.001)
+```
+
+### Test Data
+
+Place test data files in `tests/data/`. Reference them using the `get_data_file` fixture from `conftest.py`.
+
+## Pull Request Guidelines
+
+### Before Submitting
+
+- [ ] All tests pass (`pixi run test`)
+- [ ] Pre-commit hooks pass (`pixi run pre-commit`)
+- [ ] New code has appropriate test coverage
+- [ ] Docstrings are updated for public APIs
+
+### PR Description
+
+Include:
+- **Summary**: What the PR does
+- **Motivation**: Why this change is needed
+- **Test plan**: How to verify the changes work
+
+### Review Process
+
+1. Automated CI checks must pass
+2. At least one maintainer approval required
+3. Address review feedback promptly
+4. Squash commits if requested
+
+## Commit Messages
+
+Write clear, concise commit messages:
+
+```
+Short summary (50 chars or less)
+
+Optional longer description explaining the motivation
+for the change. Wrap at 72 characters.
+
+- Bullet points are fine
+- Use present tense ("Add feature" not "Added feature")
+```
+
+## Reporting Issues
+
+### Bug Reports
+
+Include:
+- Python version and OS
+- Steps to reproduce
+- Expected vs actual behavior
+- Error messages and tracebacks
+
+### Feature Requests
+
+Include:
+- Use case description
+- Proposed solution (if any)
+- Alternatives considered
+
+## Questions?
+
+- Open an issue for general questions
+- Check existing issues and documentation first
+- Tag maintainers if urgent
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the BSD-3-Clause License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2016-2026, UT-Battelle, LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
## Summary
Add comprehensive documentation for both human contributors and AI assistants working on this codebase.

## Changes

### `.github/copilot-instructions.md` (#19)
AI assistant guide covering:
- Project overview and what Bragg edges are
- Technology stack (Python 3.11+, Pixi, pytest, Ruff)
- Project structure with module descriptions
- Code style and Ruff configuration
- Testing conventions and patterns
- Development workflow and branch structure
- Domain-specific knowledge (crystal structures, materials, physical concepts)
- Common pitfalls to avoid (parameter names, import paths, etc.)

### `CONTRIBUTING.md` (#49)
Human contributor guide covering:
- Development environment setup with Pixi
- Branch workflow (next → qa → main)
- Code style and linting
- Testing guidelines and examples
- Pull request process and checklist
- Commit message conventions
- Issue reporting guidelines

## Test plan
- [x] Pre-commit hooks pass
- [ ] Documentation renders correctly on GitHub

Closes #19, closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)