### PR TITLE
Add coverage threshold enforcement and Codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true

--- a/pixi.lock
+++ b/pixi.lock
@@ -1958,8 +1958,8 @@ packages:
   timestamp: 1738196177597
 - pypi: ./
   name: neutronbraggedge
-  version: 2.1.0.dev4+d202601280127
-  sha256: e8fb3474648db2b5fcad622161b12a3e3784649190d7e626b5313e96a48606bd
+  version: 2.1.0.dev30+d202601291548
+  sha256: b6d8b237defc9676a41c4f52c2b34ac519c8f6a67a920de85b108cfa7903b4fb
   requires_dist:
   - numpy>=1.24
   - pandas>=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ branch = true
 source = ["src/neutronbraggedge"]
 
 [tool.coverage.report]
+fail_under = 80
 exclude_lines = [
   "pragma: no cover",
   "if TYPE_CHECKING:",


### PR DESCRIPTION
## Summary
Complete issue #16 by adding coverage threshold enforcement and Codecov PR comment configuration.

## Changes

### `pyproject.toml`
- Add `fail_under = 80` to enforce minimum 80% coverage in CI

### `codecov.yml` (new)
- **Project coverage**: Target 80%, allow 2% drop tolerance
- **Patch coverage**: Target 70% for new code, allow 5% tolerance
- **PR comments**: Shows coverage diff, flags, and affected files

## Current Status
- Coverage: **95%** (well above 80% threshold)
- Tests: 104 passed, 1 skipped

## Test Output
```
Required test coverage of 80.0% reached. Total coverage: 94.81%
```

## Test plan
- [x] Tests pass with threshold enforcement
- [x] Pre-commit hooks pass
- [ ] Codecov PR comment appears after merge

Closes #16

Sources:
- [Codecov YAML Reference](https://docs.codecov.com/docs/codecovyml-reference)
- [Codecov PR Comments](https://docs.codecov.com/docs/pull-request-comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)