### PR TITLE
Add dual publishing to PyPI and Conda

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.62.0
+          pixi-version: v0.63.2
           manifest-path: pyproject.toml
       - name: run unit tests
         run: |
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.62.0
+          pixi-version: v0.63.2
           manifest-path: pyproject.toml
       - name: run unit tests
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linux:
+  # Build and publish to PyPI
+  build-pypi:
+    name: Build PyPI Package
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -30,24 +29,115 @@ jobs:
         with:
           pixi-version: v0.62.0
           manifest-path: pyproject.toml
-      - name: build PyPI package
-        run: |
-          echo "Build PyPI package"
-          pixi run build
-      - name: upload PyPI artifact
-        if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/upload-artifact@v6
+      - name: Build PyPI package
+        run: pixi run build
+      - name: Upload PyPI artifact
+        uses: actions/upload-artifact@v4
         with:
           name: pypi-package
           path: dist/*
-      - name: publish PyPI package
-        if: startsWith(github.ref, 'refs/tags/v')
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build-pypi
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/neutronbraggedge
+    permissions:
+      id-token: write  # Required for trusted publishing
+    steps:
+      - name: Download PyPI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-package
+          path: dist/
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  # Build and publish to Conda
+  build-conda:
+    name: Build Conda Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # Full history for versioningit
+      - name: Get version from tag or versioningit
+        id: version
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION="${{ github.ref_name }}"
+            VERSION="${VERSION#v}"  # Remove 'v' prefix
+          else
+            pip install versioningit
+            VERSION=$(versioningit .)
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Package version: $VERSION"
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: "3.11"
+          channels: conda-forge
+          channel-priority: strict
+      - name: Install conda-build
+        shell: bash -el {0}
+        run: conda install -y conda-build anaconda-client
+      - name: Build Conda package
+        shell: bash -el {0}
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          conda build conda.recipe --output-folder conda-bld
+          ls -la conda-bld/noarch/
+      - name: Upload Conda artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: conda-package
+          path: conda-bld/noarch/*.tar.bz2
+
+  publish-conda:
+    name: Publish to Anaconda.org
+    needs: build-conda
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          python-version: "3.11"
+      - name: Install anaconda-client
+        shell: bash -el {0}
+        run: conda install -y anaconda-client
+      - name: Download Conda artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: conda-package
+          path: conda-pkg/
+      - name: Determine label
+        id: label
+        run: |
+          if [[ "${{ github.ref_name }}" == *"rc"* ]] || [[ "${{ github.ref_name }}" == *"alpha"* ]] || [[ "${{ github.ref_name }}" == *"beta"* ]]; then
+            echo "label=rc" >> $GITHUB_OUTPUT
+          else
+            echo "label=main" >> $GITHUB_OUTPUT
+          fi
+      - name: Upload to Anaconda.org
+        shell: bash -el {0}
+        env:
+          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+        run: |
+          anaconda -t $ANACONDA_TOKEN upload \
+            --user neutronimaging \
+            --label ${{ steps.label.outputs.label }} \
+            conda-pkg/*.tar.bz2
 
   # Create GitHub Release with auto-generated release notes
   github-release:
     name: Create GitHub Release
-    needs: linux
+    needs: [build-pypi, build-conda]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -56,21 +146,30 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download PyPI artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v4
         with:
           name: pypi-package
           path: dist/pypi
+
+      - name: Download Conda artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: conda-package
+          path: dist/conda
 
       - name: List artifacts
         run: |
           echo "PyPI packages:"
           ls -la dist/pypi/
+          echo "Conda packages:"
+          ls -la dist/conda/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/pypi/*
+            dist/conda/*
           generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, 'rc') || contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,12 +27,12 @@ jobs:
           fetch-depth: 0  # Full history for versioningit
       - uses: prefix-dev/setup-pixi@v0.9.4
         with:
-          pixi-version: v0.62.0
+          pixi-version: v0.63.2
           manifest-path: pyproject.toml
       - name: Build PyPI package
         run: pixi run build
       - name: Upload PyPI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: pypi-package
           path: dist/*
@@ -49,10 +49,10 @@ jobs:
       id-token: write  # Required for trusted publishing
     steps:
       - name: Download PyPI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pypi-package
-          path: dist/
+          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
@@ -93,7 +93,7 @@ jobs:
           conda build conda.recipe --output-folder conda-bld
           ls -la conda-bld/noarch/
       - name: Upload Conda artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: conda-package
           path: conda-bld/noarch/*.tar.bz2
@@ -112,10 +112,10 @@ jobs:
         shell: bash -el {0}
         run: conda install -y anaconda-client
       - name: Download Conda artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: conda-package
-          path: conda-pkg/
+          path: conda-pkg
       - name: Determine label
         id: label
         run: |
@@ -146,13 +146,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download PyPI artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: pypi-package
           path: dist/pypi
 
       - name: Download Conda artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: conda-package
           path: dist/conda

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,51 @@
+{% set name = "neutronbraggedge" %}
+{% set version = environ.get('PACKAGE_VERSION', '0.0.0') %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+
+requirements:
+  host:
+    - python >=3.11,<3.13
+    - pip
+    - setuptools >=61.0
+    - wheel
+    - versioningit >=3.0
+  run:
+    - python >=3.11,<3.13
+    - numpy >=1.24
+    - pandas >=2.0
+    - lxml >=4.9
+    - beautifulsoup4 >=4.12
+    - html5lib >=1.1
+
+test:
+  imports:
+    - neutronbraggedge
+    - neutronbraggedge.braggedge
+
+about:
+  home: https://github.com/ornlneutronimaging/BraggEdge
+  license: BSD-3-Clause
+  license_file: LICENSE
+  summary: Bragg Edge calculations for neutron imaging
+  description: |
+    A Python library for neutron Bragg edge analysis used in neutron imaging
+    research at Oak Ridge National Laboratory. Calculates Bragg edge positions,
+    d-spacings, lattice parameters, and wavelength/TOF conversions.
+  dev_url: https://github.com/ornlneutronimaging/BraggEdge
+  doc_url: https://braggedge.readthedocs.io/
+
+extra:
+  recipe-maintainers:
+    - JeanBilworx
+    - KedoKudo


### PR DESCRIPTION
## Summary

- Add `conda.recipe/meta.yaml` for conda package building (noarch Python package)
- Restructure `publish.yml` workflow with separate build and publish jobs for better security
- Add conda build and publish jobs using `conda-incubator/setup-miniconda@v3`
- Support `rc`/`alpha`/`beta` labels for pre-releases on Anaconda.org
- Include both PyPI and Conda packages in GitHub releases
- Use PyPI Trusted Publishing (OIDC) for secure, tokenless authentication

## Configuration Required

Before first release, the following needs to be configured:

1. **PyPI Trusted Publishing**: Configure at https://pypi.org/manage/project/neutronbraggedge/settings/publishing/
   - Publisher: GitHub Actions
   - Repository: `ornlneutronimaging/BraggEdge`
   - Workflow: `publish.yml`
   - Environment: `pypi`

2. **Anaconda Token**: Add `ANACONDA_TOKEN` secret to repository secrets
   - Generate at https://anaconda.org/neutronimaging/settings/access
   - Token needs read and write API access

3. **GitHub Environment**: Create `pypi` environment in repository settings for additional protection

## Publishing Behavior

| Tag Pattern | PyPI | Conda Label | GitHub Release |
|-------------|------|-------------|----------------|
| `v2.1.0` | ✅ | `main` | Release |
| `v2.1.0rc1` | ✅ | `rc` | Pre-release |
| `v2.1.0alpha1` | ✅ | `rc` | Pre-release |

## Test plan

- [ ] Verify CI passes (build jobs run on every push)
- [ ] Configure PyPI Trusted Publishing
- [ ] Add ANACONDA_TOKEN secret
- [ ] Test with a pre-release tag (e.g., `v2.1.0rc1`)

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)