### PR TITLE
PR 1: Infrastructure & Pydantic Models

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
     - lxml >=4.9
     - beautifulsoup4 >=4.12
     - html5lib >=1.1
+    - pydantic >=2.0
+    - loguru >=0.7
 
 test:
   imports:

--- a/pixi.lock
+++ b/pixi.lock
@@ -11,6 +11,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -49,6 +50,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py312h63ddcf0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
@@ -61,6 +63,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
@@ -78,6 +82,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.1.0-py312hd9148b4_0.conda
@@ -91,6 +96,7 @@ environments:
       - pypi: ./
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -123,6 +129,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxslt-1.1.43-h486b42e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.8-h472b3d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lxml-6.0.2-py312hd94307c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
@@ -135,6 +142,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.41.5-py312h8a6388b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
@@ -152,6 +161,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.1.0-py312h0aa9c5c_0.conda
@@ -164,6 +174,7 @@ environments:
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -197,6 +208,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.43-hb2570ba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.8-h4a912ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.2-py312h447b5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
@@ -209,6 +221,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
@@ -226,6 +240,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.1.0-py312h766f71e_0.conda
@@ -248,6 +263,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
@@ -289,6 +305,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py312h63ddcf0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_0.conda
@@ -300,6 +317,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.0-py312h8ecdadd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_2_cpython.conda
@@ -326,6 +345,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -336,6 +356,7 @@ environments:
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/backports.zstd-1.3.0-py312h6917036_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
@@ -371,6 +392,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxslt-1.1.43-h486b42e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-21.1.8-h472b3d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lxml-6.0.2-py312hd94307c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.3-py312hacf3034_0.conda
@@ -382,6 +404,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.0-h230baf5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.0-py312hc7bc305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.41.5-py312h8a6388b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.12-h74c2667_2_cpython.conda
@@ -408,6 +432,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h7142dee_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -418,6 +443,7 @@ environments:
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/backports.zstd-1.3.0-py312h44dc372_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
@@ -454,6 +480,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.43-hb2570ba_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-21.1.8-h4a912ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.2-py312h447b5cf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py312h5748b74_0.conda
@@ -465,6 +492,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.0-h5503f6c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.0-py312hae6be28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.12-h18782d2_2_cpython.conda
@@ -491,6 +520,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
@@ -553,6 +583,18 @@ packages:
   - pkg:pypi/alabaster?source=hash-mapping
   size: 18684
   timestamp: 1733750512696
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  md5: 2934f256a8acfe48f6ebb4fce6cde29c
+  depends:
+  - python >=3.9
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-types?source=hash-mapping
+  size: 18074
+  timestamp: 1733247158254
 - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.17.0-pyhd8ed1ab_0.conda
   sha256: 1c656a35800b7f57f7371605bc6507c8d3ad60fbaaec65876fce7f73df1fc8ac
   md5: 0a01c169f0ab0f91b26e77a3301fbfe4
@@ -1779,6 +1821,18 @@ packages:
   purls: []
   size: 285974
   timestamp: 1765964756583
+- conda: https://conda.anaconda.org/conda-forge/noarch/loguru-0.7.3-pyh707e725_0.conda
+  sha256: e4a07f357a4cf195a2345dabd98deab80f4d53574abe712a9cc7f22d3f2cc2c3
+  md5: 49647ac1de4d1e4b49124aedf3934e02
+  depends:
+  - __unix
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/loguru?source=hash-mapping
+  size: 59696
+  timestamp: 1746634858826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.2-py312h63ddcf0_2.conda
   sha256: 60000e93b2d65072abe97a98c85f987ffd47fa1ee612eeafeb2ccd0f48f9c74c
   md5: a12c2fbcb3a5a7fa24e5fb8468368b1b
@@ -1958,14 +2012,16 @@ packages:
   timestamp: 1738196177597
 - pypi: ./
   name: neutronbraggedge
-  version: 2.1.0.dev30+d202601291548
-  sha256: b6d8b237defc9676a41c4f52c2b34ac519c8f6a67a920de85b108cfa7903b4fb
+  version: 2.1.0.dev35+d202601291848
+  sha256: db70536b99b276013185b59d779533c5174adfec076e7df02ccbb4b68977d17a
   requires_dist:
   - numpy>=1.24
   - pandas>=2.0
   - lxml>=4.9
   - beautifulsoup4>=4.12
   - html5lib>=1.1
+  - pydantic>=2.0
+  - loguru>=0.7
   requires_python: '>=3.11,<3.13'
 - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
   sha256: 4fa40e3e13fc6ea0a93f67dfc76c96190afd7ea4ffc1bac2612d954b42cdc3ee
@@ -2319,6 +2375,73 @@ packages:
   - pkg:pypi/pycparser?source=hash-mapping
   size: 110100
   timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
+  sha256: 868569d9505b7fe246c880c11e2c44924d7613a8cdcc1f6ef85d5375e892f13d
+  md5: c3946ed24acdb28db1b5d63321dbca7d
+  depends:
+  - typing-inspection >=0.4.2
+  - typing_extensions >=4.14.1
+  - python >=3.10
+  - typing-extensions >=4.6.1
+  - annotated-types >=0.6.0
+  - pydantic-core ==2.41.5
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic?source=hash-mapping
+  size: 340482
+  timestamp: 1764434463101
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+  sha256: 07f899d035e06598682d3904d55f1529fac71b15e12b61d44d6a5fbf8521b0fe
+  md5: 56a776330a7d21db63a7c9d6c3711a04
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1935221
+  timestamp: 1762989004359
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.41.5-py312h8a6388b_1.conda
+  sha256: af6a81fdc058bcd22c87948df34744b33d622fbc12333cd4d2312b941b3205ec
+  md5: 8ab9943e70b341775f266f8fd1e2911b
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - __osx >=10.13
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1939222
+  timestamp: 1762989023771
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.41.5-py312h6ef9ec0_1.conda
+  sha256: 048da0a49d644dba126905a1abcea0aee75efe88b5d621b9007b569dd753cfbc
+  md5: 88a76b4c912b6127d64298e3d8db980c
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1769018
+  timestamp: 1762989029329
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -2915,6 +3038,18 @@ packages:
   purls: []
   size: 91383
   timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
+  sha256: 70db27de58a97aeb7ba7448366c9853f91b21137492e0b4430251a1870aa8ff4
+  md5: a0a4a3035667fc34f29bfbd5c190baa6
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typing-inspection?source=hash-mapping
+  size: 18923
+  timestamp: 1764158430324
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
   md5: 0caa1af407ecff61170c9437a808404d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ dependencies = [
   "lxml>=4.9",
   "beautifulsoup4>=4.12",
   "html5lib>=1.1",
+  "pydantic>=2.0",
+  "loguru>=0.7",
   # Note: configparser is stdlib in Python 3, no longer needed as dependency
 ]
 
@@ -103,13 +105,43 @@ line-length = 120
 exclude = ["notebooks/**", "**/*.ipynb", "docs/_build/**"]
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "UP"]
+select = ["E", "F", "I", "W", "UP", "D"]
 ignore = [
   "E701",  # Multiple statements on one line (colon) - existing code style, fix in #22
   "E722",  # Bare except - existing code, fix in #22
   "E741",  # Ambiguous variable name (l) - h,k,l are standard Miller indices notation
   "UP031", # Use format specifiers instead of percent format - fix in #22
+  # Docstring rules - will be fixed in PR3 (#56)
+  "D100",  # Missing docstring in public module
+  "D101",  # Missing docstring in public class
+  "D102",  # Missing docstring in public method
+  "D103",  # Missing docstring in public function
+  "D104",  # Missing docstring in public package
+  "D105",  # Missing docstring in magic method
+  "D107",  # Missing docstring in __init__
+  "D200",  # One-line docstring should fit on one line
+  "D202",  # No blank lines allowed after function docstring
+  "D205",  # 1 blank line required between summary and description
+  "D209",  # Multi-line docstring closing quotes should be on separate line
+  "D400",  # First line should end with a period
+  "D401",  # First line should be in imperative mood
+  "D403",  # First word of docstring should be capitalized
+  "D404",  # First word of docstring should not be "This"
+  "D406",  # Section name should end with a newline
+  "D407",  # Missing dashed underline after section
+  "D410",  # Missing blank line after section
+  "D411",  # Missing blank line before section
+  "D412",  # No blank lines allowed between section header and content
+  "D414",  # Section has no content
+  "D415",  # First line should end with period, question mark, or exclamation point
+  "D417",  # Missing argument descriptions in docstring
 ]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["D"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["neutronbraggedge"]
@@ -134,6 +166,8 @@ pandas = ">=2.0"
 lxml = ">=4.9"
 beautifulsoup4 = ">=4.12"
 html5lib = ">=1.1"
+pydantic = ">=2.0"
+loguru = ">=0.7"
 
 [tool.pixi.tasks]
 # Testing

--- a/src/neutronbraggedge/__init__.py
+++ b/src/neutronbraggedge/__init__.py
@@ -1,7 +1,48 @@
 """Neutron Bragg Edge calculations for crystalline materials."""
 
+from loguru import logger
+
+from .logging_config import configure_logging, disable_logging, enable_logging
+from .models import (
+    BraggEdgeEntry,
+    BraggEdgeResult,
+    CrystalStructure,
+    ExperimentConfig,
+    LatticeCalculationInput,
+    LatticeResult,
+    LatticeStatistics,
+    MaterialConfig,
+    MaterialMetadata,
+    TOFData,
+)
+
 try:
     from ._version import __version__
 except ImportError:
     # Package not installed, use fallback
     __version__ = "0.0.0.dev0"
+
+# Disable logger by default (library best practice)
+# Users can enable with: configure_logging() or enable_logging()
+logger.disable("neutronbraggedge")
+
+__all__ = [
+    # Version
+    "__version__",
+    # Logging
+    "logger",
+    "configure_logging",
+    "enable_logging",
+    "disable_logging",
+    # Models
+    "CrystalStructure",
+    "MaterialConfig",
+    "MaterialMetadata",
+    "BraggEdgeEntry",
+    "BraggEdgeResult",
+    "ExperimentConfig",
+    "TOFData",
+    "LatticeCalculationInput",
+    "LatticeStatistics",
+    "LatticeResult",
+]

--- a/src/neutronbraggedge/logging_config.py
+++ b/src/neutronbraggedge/logging_config.py
@@ -1,0 +1,100 @@
+"""Logging configuration for neutronbraggedge.
+
+This module provides Loguru-based logging configuration for the library.
+By default, the logger is disabled to follow library best practices.
+Users can enable logging by calling configure_logging().
+"""
+
+import sys
+
+from loguru import logger
+
+# Remove default handler - library best practice is to not emit logs by default
+logger.remove()
+
+
+# Default log format
+DEFAULT_FORMAT = (
+    "<green>{time:YYYY-MM-DD HH:mm:ss}</green> | "
+    "<level>{level: <8}</level> | "
+    "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
+    "<level>{message}</level>"
+)
+
+
+def configure_logging(
+    level: str = "INFO",
+    format: str = DEFAULT_FORMAT,
+    colorize: bool = True,
+) -> None:
+    """Configure logging for neutronbraggedge.
+
+    Parameters
+    ----------
+    level : str, optional
+        Logging level. Default is "INFO".
+        Valid levels: "TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL".
+    format : str, optional
+        Log message format string using Loguru format syntax.
+    colorize : bool, optional
+        Whether to colorize output. Default is True.
+
+    Examples
+    --------
+    Enable logging with default settings:
+
+    >>> from neutronbraggedge.logging_config import configure_logging
+    >>> configure_logging()
+
+    Enable debug logging:
+
+    >>> configure_logging(level="DEBUG")
+
+    Simple format without colors (for file output):
+
+    >>> configure_logging(
+    ...     format="{time} | {level} | {message}",
+    ...     colorize=False
+    ... )
+    """
+    # Remove any existing handlers before adding new one
+    logger.remove()
+
+    # Add stdout handler with specified configuration
+    logger.add(
+        sys.stdout,
+        level=level,
+        format=format,
+        colorize=colorize,
+    )
+
+
+def enable_logging(level: str = "INFO") -> None:
+    """Enable logging with sensible defaults.
+
+    This is a convenience function that calls configure_logging with
+    default parameters.
+
+    Parameters
+    ----------
+    level : str, optional
+        Logging level. Default is "INFO".
+
+    Examples
+    --------
+    >>> from neutronbraggedge.logging_config import enable_logging
+    >>> enable_logging()  # Enable INFO level logging
+    >>> enable_logging("DEBUG")  # Enable DEBUG level logging
+    """
+    configure_logging(level=level)
+
+
+def disable_logging() -> None:
+    """Disable all logging output.
+
+    Examples
+    --------
+    >>> from neutronbraggedge.logging_config import disable_logging
+    >>> disable_logging()
+    """
+    logger.remove()

--- a/src/neutronbraggedge/models.py
+++ b/src/neutronbraggedge/models.py
@@ -1,0 +1,308 @@
+"""Pydantic models for neutronbraggedge.
+
+This module defines data models using Pydantic for type validation and
+serialization of Bragg edge calculations and experimental data.
+"""
+
+from typing import Literal
+
+import numpy as np
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Type alias for supported crystal structures
+CrystalStructure = Literal["BCC", "FCC"]
+
+
+class MaterialConfig(BaseModel):
+    """Configuration for a custom material.
+
+    Parameters
+    ----------
+    name : str
+        Material name/symbol (e.g., "Fe", "Ni").
+    lattice : float
+        Lattice constant in Angstroms. Must be positive.
+    crystal_structure : CrystalStructure
+        Crystal structure type ("BCC" or "FCC").
+
+    Examples
+    --------
+    >>> config = MaterialConfig(name="Ta", lattice=3.31, crystal_structure="BCC")
+    >>> config.model_dump()
+    {'name': 'Ta', 'lattice': 3.31, 'crystal_structure': 'BCC'}
+    """
+
+    name: str = Field(..., min_length=1, description="Material name/symbol")
+    lattice: float = Field(..., gt=0, description="Lattice constant in Angstroms")
+    crystal_structure: CrystalStructure = Field(..., description="Crystal structure type")
+
+    model_config = ConfigDict(frozen=True)
+
+
+class MaterialMetadata(BaseModel):
+    """Metadata retrieved for a material.
+
+    Parameters
+    ----------
+    material : str
+        Material name/symbol.
+    lattice : float
+        Lattice constant in Angstroms.
+    crystal_structure : CrystalStructure
+        Crystal structure type ("BCC" or "FCC").
+    use_local_table : bool
+        Whether local metadata table was used.
+
+    Examples
+    --------
+    >>> metadata = MaterialMetadata(
+    ...     material="Fe",
+    ...     lattice=2.8664,
+    ...     crystal_structure="BCC",
+    ...     use_local_table=True
+    ... )
+    """
+
+    material: str = Field(..., description="Material name/symbol")
+    lattice: float = Field(..., gt=0, description="Lattice constant in Angstroms")
+    crystal_structure: CrystalStructure = Field(..., description="Crystal structure type")
+    use_local_table: bool = Field(default=True, description="Whether local metadata table was used")
+
+    model_config = ConfigDict(frozen=True)
+
+
+class BraggEdgeEntry(BaseModel):
+    """A single Bragg edge entry with hkl indices and calculated values.
+
+    Parameters
+    ----------
+    h : int
+        Miller index h.
+    k : int
+        Miller index k.
+    l : int
+        Miller index l.
+    d_spacing : float
+        Interplanar spacing in Angstroms.
+    bragg_edge : float
+        Bragg edge wavelength in Angstroms.
+    """
+
+    h: int = Field(..., description="Miller index h")
+    k: int = Field(..., description="Miller index k")
+    l: int = Field(..., description="Miller index l")
+    d_spacing: float = Field(..., description="Interplanar spacing in Angstroms")
+    bragg_edge: float = Field(..., description="Bragg edge wavelength in Angstroms")
+
+    model_config = ConfigDict(frozen=True)
+
+
+class BraggEdgeResult(BaseModel):
+    """Complete Bragg edge calculation results for a material.
+
+    Parameters
+    ----------
+    material : str
+        Material name/symbol.
+    lattice : float
+        Lattice constant in Angstroms.
+    crystal_structure : CrystalStructure
+        Crystal structure type.
+    use_local_table : bool
+        Whether local metadata table was used.
+    entries : list[BraggEdgeEntry]
+        List of Bragg edge entries with hkl and calculated values.
+
+    Examples
+    --------
+    >>> result = BraggEdgeResult(
+    ...     material="Fe",
+    ...     lattice=2.8664,
+    ...     crystal_structure="BCC",
+    ...     use_local_table=True,
+    ...     entries=[
+    ...         BraggEdgeEntry(h=1, k=1, l=0, d_spacing=2.0269, bragg_edge=4.0537)
+    ...     ]
+    ... )
+    >>> result.model_dump_json()  # Serialize to JSON
+    """
+
+    material: str = Field(..., description="Material name/symbol")
+    lattice: float = Field(..., gt=0, description="Lattice constant in Angstroms")
+    crystal_structure: CrystalStructure = Field(..., description="Crystal structure type")
+    use_local_table: bool = Field(default=True, description="Whether local metadata table was used")
+    entries: list[BraggEdgeEntry] = Field(default_factory=list, description="Bragg edge entries")
+
+    model_config = ConfigDict(frozen=True)
+
+    @property
+    def hkl(self) -> list[tuple[int, int, int]]:
+        """Get list of (h, k, l) tuples."""
+        return [(e.h, e.k, e.l) for e in self.entries]
+
+    @property
+    def d_spacing(self) -> list[float]:
+        """Get list of d-spacing values."""
+        return [e.d_spacing for e in self.entries]
+
+    @property
+    def bragg_edges(self) -> list[float]:
+        """Get list of Bragg edge values."""
+        return [e.bragg_edge for e in self.entries]
+
+
+class ExperimentConfig(BaseModel):
+    """Configuration for an experiment calculation.
+
+    Parameters
+    ----------
+    tof_array : list[float]
+        Time-of-flight array in seconds.
+    distance_source_detector_m : float, optional
+        Distance from source to detector in meters.
+    detector_offset_micros : float, optional
+        Detector time offset in microseconds.
+    lambda_array : list[float], optional
+        Wavelength array in Angstroms.
+
+    Notes
+    -----
+    Either lambda_array must be provided with one of distance/offset,
+    or both distance and offset must be provided to calculate lambda.
+    """
+
+    tof_array: list[float] = Field(..., description="Time-of-flight array in seconds")
+    distance_source_detector_m: float | None = Field(
+        default=None, description="Distance from source to detector in meters"
+    )
+    detector_offset_micros: float | None = Field(default=None, description="Detector time offset in microseconds")
+    lambda_array: list[float] | None = Field(default=None, description="Wavelength array in Angstroms")
+
+    model_config = ConfigDict(frozen=True)
+
+
+class TOFData(BaseModel):
+    """Time-of-flight data container.
+
+    Parameters
+    ----------
+    tof_array : list[float]
+        Time-of-flight values in seconds.
+    counts_array : list[float], optional
+        Corresponding counts/intensity values.
+    units : str
+        Original units of the TOF data before conversion.
+
+    Examples
+    --------
+    >>> tof = TOFData(tof_array=[1e-6, 2e-6, 3e-6], units="s")
+    """
+
+    tof_array: list[float] = Field(..., description="Time-of-flight values in seconds")
+    counts_array: list[float] | None = Field(default=None, description="Counts/intensity values")
+    units: str = Field(default="s", description="Original units of TOF data")
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_validator("tof_array", "counts_array", mode="before")
+    @classmethod
+    def convert_numpy_array(cls, v):
+        """Convert numpy arrays to lists for JSON serialization."""
+        if isinstance(v, np.ndarray):
+            return v.tolist()
+        return v
+
+
+class LatticeCalculationInput(BaseModel):
+    """Input parameters for lattice calculation.
+
+    Parameters
+    ----------
+    material : str, optional
+        Material name/symbol.
+    crystal_structure : CrystalStructure
+        Crystal structure type.
+    bragg_edge_array : list[float]
+        Array of experimental Bragg edge values.
+    bragg_edge_error_array : list[float], optional
+        Array of errors for Bragg edge values.
+
+    Examples
+    --------
+    >>> input_data = LatticeCalculationInput(
+    ...     material="Fe",
+    ...     crystal_structure="BCC",
+    ...     bragg_edge_array=[4.05, 2.87, 2.34, 2.03]
+    ... )
+    """
+
+    material: str | None = Field(default=None, description="Material name/symbol")
+    crystal_structure: CrystalStructure = Field(..., description="Crystal structure type")
+    bragg_edge_array: list[float] = Field(..., description="Experimental Bragg edge values")
+    bragg_edge_error_array: list[float] | None = Field(default=None, description="Bragg edge error values")
+
+    model_config = ConfigDict(frozen=True)
+
+
+class LatticeStatistics(BaseModel):
+    """Statistical results from lattice parameter calculations.
+
+    Parameters
+    ----------
+    min : float
+        Minimum lattice parameter value.
+    max : float
+        Maximum lattice parameter value.
+    median : float
+        Median lattice parameter value.
+    mean : float
+        Mean lattice parameter value.
+    mean_error : float
+        Error in mean lattice parameter.
+    std : float
+        Standard deviation of lattice parameters.
+
+    Examples
+    --------
+    >>> stats = LatticeStatistics(
+    ...     min=2.85, max=2.88, median=2.866,
+    ...     mean=2.8664, mean_error=0.001, std=0.01
+    ... )
+    """
+
+    min: float = Field(..., description="Minimum lattice parameter")
+    max: float = Field(..., description="Maximum lattice parameter")
+    median: float = Field(..., description="Median lattice parameter")
+    mean: float = Field(..., description="Mean lattice parameter")
+    mean_error: float = Field(..., description="Error in mean lattice parameter")
+    std: float = Field(..., description="Standard deviation")
+
+    model_config = ConfigDict(frozen=True)
+
+
+class LatticeResult(BaseModel):
+    """Complete lattice calculation results.
+
+    Parameters
+    ----------
+    material : str, optional
+        Material name/symbol.
+    crystal_structure : CrystalStructure
+        Crystal structure type.
+    lattice_array : list[float]
+        Calculated lattice parameters for each hkl.
+    lattice_error_array : list[float]
+        Errors in lattice parameters.
+    statistics : LatticeStatistics
+        Statistical summary of lattice parameters.
+    hkl_bragg_edge : list[tuple]
+        List of (hkl, bragg_edge, error) tuples.
+    """
+
+    material: str | None = Field(default=None, description="Material name/symbol")
+    crystal_structure: CrystalStructure = Field(..., description="Crystal structure type")
+    lattice_array: list[float] = Field(..., description="Calculated lattice parameters")
+    lattice_error_array: list[float] = Field(..., description="Lattice parameter errors")
+    statistics: LatticeStatistics = Field(..., description="Statistical summary")
+
+    model_config = ConfigDict(frozen=True)


### PR DESCRIPTION
## Summary
- Add `pydantic>=2.0` and `loguru>=0.7` dependencies to project
- Create Pydantic models for type-safe data handling across the codebase
- Configure Loguru logging with library best practices (disabled by default)
- Add D rules to Ruff for NumPy docstring convention (with temporary ignores)

## Changes

### New Files
- `src/neutronbraggedge/models.py` - Pydantic models:
  - `CrystalStructure` type alias (`Literal["BCC", "FCC"]`)
  - `MaterialConfig`, `MaterialMetadata` - material data
  - `BraggEdgeEntry`, `BraggEdgeResult` - calculation results
  - `ExperimentConfig`, `TOFData` - experiment data
  - `LatticeCalculationInput`, `LatticeStatistics`, `LatticeResult` - lattice calculations

- `src/neutronbraggedge/logging_config.py` - Loguru configuration:
  - `configure_logging()` - full configuration
  - `enable_logging()` / `disable_logging()` - convenience functions

### Modified Files
- `pyproject.toml` - Dependencies and Ruff docstring rules
- `src/neutronbraggedge/__init__.py` - Export models and logging utilities
- `pixi.lock` - Updated dependencies

## Test plan
- [x] `pixi run test` - All 104 tests pass (94.11% coverage)
- [x] `pixi run lint` - All Ruff checks pass

## Related Issues
Closes #54
Part of #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)