### PR TITLE
ci: install conda-build into base env so `conda build` resolves

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,8 +83,11 @@ jobs:
           channels: conda-forge
           channel-priority: strict
       - name: Install conda-build
+        # Install into base: `conda build` is a base-env subcommand plugin,
+        # resolved from the env where conda itself runs (base) — not the
+        # auto-activated `test` env where `conda install` would land it.
         shell: bash -el {0}
-        run: conda install -y conda-build anaconda-client
+        run: conda install -y -n base conda-build anaconda-client
       - name: Build Conda package
         shell: bash -el {0}
         env:


### PR DESCRIPTION
## Problem

Packaging on `next` is red. The `build-conda` job fails at the build step:

```
conda: error: argument COMMAND: invalid choice: 'build'
```

## Root cause — toolchain drift, not the dependency bumps

The `Install conda-build` step ran `conda install -y conda-build anaconda-client`, which lands in setup-miniconda's **auto-activated `test` env** (`/usr/share/miniconda/envs/test`). But `conda build` is a **subcommand plugin** resolved from the env where `conda` itself runs — **base**. Newer conda (pulled fresh every run by `auto-update-conda: true`) no longer surfaces a plugin installed in `test`, so `conda build` is unknown.

Evidence this is drift and not a code/action change:

| When | setup-miniconda | Build Conda Package |
|------|-----------------|---------------------|
| 2026-04-28 (#65 PR run) | v4 | ✅ pass |
| 2026-05-01 (dependabot PR runs) | v3 | ✅ pass |
| 2026-06-29 (merge to `next`) | v4 | ❌ fail |

Same workflow, same recipe — only the floating conda version differs.

## Fix

Install conda-build into **base** (`-n base`) so `conda build` resolves regardless of the active env. One-line change.

## Follow-up (not in this PR)

`auto-update-conda: true` will keep pulling the latest conda each run; consider pinning a conda/miniconda version later to make packaging reproducible.

Assisted-With: Claude Opus 4.8 (1M context) <noreply@anthropic.com>