### PR TITLE
ci: stop dependabot from gratuitously raising dependency floors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 10
     target-branch: "next"
+    # Only raise a dependency's >= floor when the current floor actually
+    # excludes the latest version. Stops gratuitous minimum-version bumps
+    # (the source of the #66-73 churn); pixi.lock movement is handled by the
+    # update-lockfiles cron, and security updates still bump when needed.
+    versioning-strategy: increase-if-necessary
     labels:
       - "dependencies"
       - "python"


### PR DESCRIPTION
## Why

The pip ecosystem in `.github/dependabot.yml` had no `versioning-strategy`, so dependabot defaulted to `increase` — it raised `>=` floors even when the existing floor already permitted the latest version. That's what produced #66–73 (numpy 1.24→2.4.4, pandas 2.0→3.0.2, lxml 4.9→6.1.0, …): eight floor bumps that were **no-ops against the pixi.lock** and only ever turned CI red because dependabot can't regenerate `pixi.lock`.

## What

Adds `versioning-strategy: increase-if-necessary` to the pip ecosystem. Now a floor is bumped **only** when the current one actually excludes the latest resolvable version. Effects:
- No more gratuitous minimum-version PRs.
- Real version movement stays with the `update-lockfiles` cron (`pixi update`), which is the only thing that *can* relock pixi.
- Security updates still bump a floor when a fix requires it.

Config-only change; one line (plus an explanatory comment).

Assisted-With: Claude Opus 4.8 (1M context) <noreply@anthropic.com>