### PR TITLE
deps: reconcile [project] floors to runtime minimums (undo aggressive bumps)

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3416,11 +3416,11 @@ packages:
 - pypi: ./
   name: neutronbraggedge
   requires_dist:
-  - numpy>=2.4.4
-  - pandas>=3.0.2
-  - lxml>=6.1.0
-  - beautifulsoup4>=4.14.3
+  - numpy>=1.24
+  - pandas>=2.0
+  - lxml>=4.9
+  - beautifulsoup4>=4.12
   - html5lib>=1.1
-  - pydantic>=2.13.3
-  - loguru>=0.7.3
+  - pydantic>=2.0
+  - loguru>=0.7
   requires_python: '>=3.11,<3.13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,13 @@ requires-python = ">=3.11,<3.13"
 license = "BSD-3-Clause"
 keywords = ["Bragg Edge", "neutron", "imaging", "crystallography", "diffraction"]
 dependencies = [
-  "numpy>=2.4.4",
-  "pandas>=3.0.2",
-  "lxml>=6.1.0",
-  "beautifulsoup4>=4.14.3",
+  "numpy>=1.24",
+  "pandas>=2.0",
+  "lxml>=4.9",
+  "beautifulsoup4>=4.12",
   "html5lib>=1.1",
-  "pydantic>=2.13.3",
-  "loguru>=0.7.3",
+  "pydantic>=2.0",
+  "loguru>=0.7",
   # Note: configparser is stdlib in Python 3, no longer needed as dependency
 ]
 
@@ -40,9 +40,9 @@ documentation = "https://braggedge.readthedocs.io/"
 
 [build-system]
 requires = [
-  "setuptools>=82.0.1",
+  "setuptools>=61.0",
   "wheel",
-  "versioningit>=3.3.0",
+  "versioningit>=3.0",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
## Why

After #75, the two dependency-declaration sites disagreed:
- `[project.dependencies]` / `[build-system]` carried dependabot's **aggressive** floors (numpy≥2.4.4, pandas≥3.0.2, lxml≥6.1.0, beautifulsoup4≥4.14.3, pydantic≥2.13.3, loguru≥0.7.3, setuptools≥82.0.1, versioningit≥3.3.0).
- `[tool.pixi.dependencies]` kept the **original** minimums (numpy≥1.24, pandas≥2.0, …).

For a published library, a minimum floor should be the lowest *supported* version, not the latest — declaring numpy≥2.4.4 / pandas≥3.0.2 as minimums needlessly blocks downstream users who pin older-but-fine versions. Those bumps originated from mechanical dependabot PRs (#66–73), not a code requirement.

## What

Reverts the `[project]`/`[build-system]` floors to the pre-#75 minimums, so both sites now agree (verified: all 7 runtime floors match `[tool.pixi.dependencies]`).

**Declaration-only** — the resolved/locked versions are unchanged (numpy 2.4.6, pandas 3.0.3, … still pinned); only the embedded `>=` specs in `pixi.lock` drop to the new floors (6-line churn, no version moves).

## Verification
Local (pixi 0.71.2): `pixi install --locked` ✓, `pixi run test` ✓ (104 passed, 1 skipped, 93% coverage). With #77's `increase-if-necessary` now in place, dependabot won't re-raise these floors.

## Direction note
I reconciled **downward** (sane library minimums) rather than raising the conda floors to match the aggressive ones — that's the "leave it better" direction for a library. If you'd actually prefer requiring modern numpy/pandas as the floor, this is a one-line-each flip.

Assisted-With: Claude Opus 4.8 (1M context) <noreply@anthropic.com>